### PR TITLE
Streaming xmiid clash with Notification impacting UML-Yang tooling

### DIFF
--- a/UML/TapiStreaming.notation
+++ b/UML/TapiStreaming.notation
@@ -807,32 +807,6 @@
       <element xmi:type="uml:Enumeration" href="TapiStreaming.uml#_-5CrYMEfEemNuM6W9x-XhQ"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_z5_mLB-3EeqCeNa5GcKdyg" x="-464" y="-400" width="205"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_z5_mMx-3EeqCeNa5GcKdyg" type="Enumeration_Shape">
-      <children xmi:type="notation:DecorationNode" xmi:id="_z5_mNB-3EeqCeNa5GcKdyg" type="Enumeration_NameLabel"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_z5_mNR-3EeqCeNa5GcKdyg" type="Enumeration_FloatingNameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_z5_mNh-3EeqCeNa5GcKdyg" y="15"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_z5_mNx-3EeqCeNa5GcKdyg" type="Enumeration_LiteralCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_z5_mOB-3EeqCeNa5GcKdyg" type="EnumerationLiteral_LiteralLabel">
-          <element xmi:type="uml:EnumerationLiteral" href="TapiStreaming.uml#_ggplICzeEeaYO8M_h7XJ5A"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_z5_mOR-3EeqCeNa5GcKdyg"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_z5_mOh-3EeqCeNa5GcKdyg" type="EnumerationLiteral_LiteralLabel">
-          <element xmi:type="uml:EnumerationLiteral" href="TapiStreaming.uml#_h_dFcCzeEeaYO8M_h7XJ5A"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_z5_mOx-3EeqCeNa5GcKdyg"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_z5_mPB-3EeqCeNa5GcKdyg" type="EnumerationLiteral_LiteralLabel">
-          <element xmi:type="uml:EnumerationLiteral" href="TapiStreaming.uml#_jrUKUCzeEeaYO8M_h7XJ5A"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_z5_mPR-3EeqCeNa5GcKdyg"/>
-        </children>
-        <styles xmi:type="notation:TitleStyle" xmi:id="_z5_mPh-3EeqCeNa5GcKdyg"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_z5_mPx-3EeqCeNa5GcKdyg"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_z5_mQB-3EeqCeNa5GcKdyg"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_z5_mQR-3EeqCeNa5GcKdyg"/>
-      </children>
-      <element xmi:type="uml:Enumeration" href="TapiStreaming.uml#_bgwjsCzeEeaYO8M_h7XJ5A"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_z5_mRR-3EeqCeNa5GcKdyg" x="880" y="280"/>
-    </children>
     <children xmi:type="notation:Shape" xmi:id="_z5_mVR-3EeqCeNa5GcKdyg" type="DataType_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_z5_mVh-3EeqCeNa5GcKdyg" type="DataType_NameLabel"/>
       <children xmi:type="notation:DecorationNode" xmi:id="_z5_mVx-3EeqCeNa5GcKdyg" type="DataType_FloatingNameLabel">
@@ -1801,66 +1775,6 @@
       </children>
       <element xmi:type="uml:Class" href="TapiStreaming.uml#_3Uj4oD0mEeqNzoiCK4mkvg"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_3UtCkT0mEeqNzoiCK4mkvg" x="-100" y="-60" width="261" height="61"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_ufCXYD6wEeqNzoiCK4mkvg" type="Enumeration_Shape">
-      <children xmi:type="notation:DecorationNode" xmi:id="_ufGBwD6wEeqNzoiCK4mkvg" type="Enumeration_NameLabel"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_ufGo0D6wEeqNzoiCK4mkvg" type="Enumeration_FloatingNameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_ufGo0T6wEeqNzoiCK4mkvg" y="15"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_ufHP4D6wEeqNzoiCK4mkvg" type="Enumeration_LiteralCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_0O1y0D6wEeqNzoiCK4mkvg" type="EnumerationLiteral_LiteralLabel">
-          <element xmi:type="uml:EnumerationLiteral" href="TapiStreaming.uml#_-WiMANwzEeaaobmDldrjOQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_0O1y0T6wEeqNzoiCK4mkvg"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_0O3A8D6wEeqNzoiCK4mkvg" type="EnumerationLiteral_LiteralLabel">
-          <element xmi:type="uml:EnumerationLiteral" href="TapiStreaming.uml#_9MhP8NwzEeaaobmDldrjOQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_0O3A8T6wEeqNzoiCK4mkvg"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_0O42ID6wEeqNzoiCK4mkvg" type="EnumerationLiteral_LiteralLabel">
-          <element xmi:type="uml:EnumerationLiteral" href="TapiStreaming.uml#__wAgYNwzEeaaobmDldrjOQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_0O42IT6wEeqNzoiCK4mkvg"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_0O6EQD6wEeqNzoiCK4mkvg" type="EnumerationLiteral_LiteralLabel">
-          <element xmi:type="uml:EnumerationLiteral" href="TapiStreaming.uml#_At-kgNw0EeaaobmDldrjOQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_0O6EQT6wEeqNzoiCK4mkvg"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_0O7SYD6wEeqNzoiCK4mkvg" type="EnumerationLiteral_LiteralLabel">
-          <element xmi:type="uml:EnumerationLiteral" href="TapiStreaming.uml#_C8cnMNw0EeaaobmDldrjOQ"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_0O7SYT6wEeqNzoiCK4mkvg"/>
-        </children>
-        <styles xmi:type="notation:TitleStyle" xmi:id="_ufHP4T6wEeqNzoiCK4mkvg"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_ufHP4j6wEeqNzoiCK4mkvg"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_ufHP4z6wEeqNzoiCK4mkvg"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ufH28D6wEeqNzoiCK4mkvg"/>
-      </children>
-      <element xmi:type="uml:Enumeration" href="TapiStreaming.uml#_5ByU4NwzEeaaobmDldrjOQ"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ufCXYT6wEeqNzoiCK4mkvg" x="-160" y="537" width="161" height="124"/>
-    </children>
-    <children xmi:type="notation:Shape" xmi:id="_W5-8MD6xEeqNzoiCK4mkvg" type="Enumeration_Shape">
-      <children xmi:type="notation:DecorationNode" xmi:id="_W5-8Mj6xEeqNzoiCK4mkvg" type="Enumeration_NameLabel"/>
-      <children xmi:type="notation:DecorationNode" xmi:id="_W5-8Mz6xEeqNzoiCK4mkvg" type="Enumeration_FloatingNameLabel">
-        <layoutConstraint xmi:type="notation:Location" xmi:id="_W5-8ND6xEeqNzoiCK4mkvg" y="15"/>
-      </children>
-      <children xmi:type="notation:BasicCompartment" xmi:id="_W5-8NT6xEeqNzoiCK4mkvg" type="Enumeration_LiteralCompartment">
-        <children xmi:type="notation:Shape" xmi:id="_fsq50D6xEeqNzoiCK4mkvg" type="EnumerationLiteral_LiteralLabel">
-          <element xmi:type="uml:EnumerationLiteral" href="TapiStreaming.uml#_D2NBYOcDEeaDNtnUN91VDg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_fsq50T6xEeqNzoiCK4mkvg"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_fssH8D6xEeqNzoiCK4mkvg" type="EnumerationLiteral_LiteralLabel">
-          <element xmi:type="uml:EnumerationLiteral" href="TapiStreaming.uml#_FvNKYOcDEeaDNtnUN91VDg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_fssH8T6xEeqNzoiCK4mkvg"/>
-        </children>
-        <children xmi:type="notation:Shape" xmi:id="_fssH8j6xEeqNzoiCK4mkvg" type="EnumerationLiteral_LiteralLabel">
-          <element xmi:type="uml:EnumerationLiteral" href="TapiStreaming.uml#_HCD5YOcDEeaDNtnUN91VDg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_fssH8z6xEeqNzoiCK4mkvg"/>
-        </children>
-        <styles xmi:type="notation:TitleStyle" xmi:id="_W5-8Nj6xEeqNzoiCK4mkvg"/>
-        <styles xmi:type="notation:SortingStyle" xmi:id="_W5-8Nz6xEeqNzoiCK4mkvg"/>
-        <styles xmi:type="notation:FilteringStyle" xmi:id="_W5-8OD6xEeqNzoiCK4mkvg"/>
-        <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W5-8OT6xEeqNzoiCK4mkvg"/>
-      </children>
-      <element xmi:type="uml:Enumeration" href="TapiStreaming.uml#_5QUAwOcCEeaDNtnUN91VDg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_W5-8MT6xEeqNzoiCK4mkvg" x="-160" y="420" width="221"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_izM5IHVoEeqfmpW3vMmyvQ" type="Enumeration_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_izNgMHVoEeqfmpW3vMmyvQ" type="Enumeration_NameLabel"/>
@@ -3290,245 +3204,245 @@
       <element xmi:type="uml:Class" href="TapiStreaming.uml#_3Uj4oD0mEeqNzoiCK4mkvg"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_O8kbLUHbEeqO_YO5cZovrw" x="-160" y="20" width="181" height="81"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_FISXUHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_FISXUXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FISXU3ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_qArm0H5YEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_qArm0X5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qArm035YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_eXlBcGWwEemRDKXaAompzQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FISXUnppEeqMpJXtwtppeQ" x="440" y="-140"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qArm0n5YEeqCy67P6xy4tg" x="440" y="-140"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_FIekkHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_FIekkXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FIfLoHppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_qA2l8H5YEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_qA2l8X5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qA2l835YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiStreaming.uml#_X3gNYGW1EemRDKXaAompzQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FIekknppEeqMpJXtwtppeQ" x="440" y="-240"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qA2l8n5YEeqCy67P6xy4tg" x="440" y="-240"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_FIlSQHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_FIlSQXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FIlSQ3ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_qA8skH5YEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_qA8skX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qA9ToH5YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiStreaming.uml#_YZxM8GW1EemRDKXaAompzQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FIlSQnppEeqMpJXtwtppeQ" x="440" y="-240"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qA8skn5YEeqCy67P6xy4tg" x="440" y="-240"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_FI1w8HppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_FI1w8XppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FI1w83ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_qBNyUH5YEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_qBNyUX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qBNyU35YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_im_oMGWwEemRDKXaAompzQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FI1w8nppEeqMpJXtwtppeQ" x="320" y="20"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qBNyUn5YEeqCy67P6xy4tg" x="320" y="20"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_FJLIIHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_FJLIIXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FJLII3ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_qBhUUH5YEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_qBhUUX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qBhUU35YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_lKL9sGWwEemRDKXaAompzQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FJLIInppEeqMpJXtwtppeQ" x="560" y="20"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qBhUUn5YEeqCy67P6xy4tg" x="560" y="20"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_FJfRMHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_FJfRMXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FJfRM3ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_qB02UH5YEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_qB02UX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qB02U35YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_2U15kGW1EemRDKXaAompzQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FJfRMnppEeqMpJXtwtppeQ" x="560" y="180"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qB02Un5YEeqCy67P6xy4tg" x="560" y="180"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_FJn0EHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_FJn0EXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FJn0E3ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_qB_OYH5YEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_qB_OYX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qB_OY35YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiStreaming.uml#_i2jWAG3mEemRDKXaAompzQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FJn0EnppEeqMpJXtwtppeQ" x="560" y="80"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qB_OYn5YEeqCy67P6xy4tg" x="560" y="80"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_FJvI0HppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_FJvI0XppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FJvI03ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_qCHKMH5YEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_qCHKMX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qCHKM35YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Signal" href="TapiStreaming.uml#_X9ay8LqKEemx9sMHf8Tuig"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FJvI0nppEeqMpJXtwtppeQ" x="440" y="-320"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qCHKMn5YEeqCy67P6xy4tg" x="440" y="-320"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_FJ0oYHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_FJ0oYXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FJ0oY3ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_qCN34H5YEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_qCN34X5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qCN3435YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiStreaming.uml#_s9prgLqKEemx9sMHf8Tuig"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FJ0oYnppEeqMpJXtwtppeQ" x="440" y="-420"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qCN34n5YEeqCy67P6xy4tg" x="440" y="-420"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_FKD48HppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_FKD48XppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FKD483ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_qChZ4H5YEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_qChZ4X5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qChZ435YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_gv58QLqKEemx9sMHf8Tuig"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FKD48nppEeqMpJXtwtppeQ" x="180" y="-540"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qChZ4n5YEeqCy67P6xy4tg" x="180" y="-540"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_FKORAHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_FKORAXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FKORA3ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_qCrK4H5YEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_qCrK4X5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qCrK435YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiStreaming.uml#_5n-CALqKEemx9sMHf8Tuig"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FKORAnppEeqMpJXtwtppeQ" x="180" y="-640"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qCrK4n5YEeqCy67P6xy4tg" x="180" y="-640"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_FKUXoHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_FKUXoXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FKUXo3ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_qCwDYH5YEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_qCwqcH5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qCwqcn5YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiStreaming.uml#_AiVEsLqOEemx9sMHf8Tuig"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FKUXonppEeqMpJXtwtppeQ" x="180" y="-640"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qCwqcX5YEeqCy67P6xy4tg" x="180" y="-640"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_FKcTcHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_FKcTcXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FKcTc3ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_qC3YIH5YEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_qC3YIX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qC3YI35YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiStreaming.uml#__-BWYLqQEemx9sMHf8Tuig"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FKcTcnppEeqMpJXtwtppeQ" x="180" y="-640"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qC3YIn5YEeqCy67P6xy4tg" x="180" y="-640"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_FLBiQHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_FLBiQXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FLBiQ3ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_qDb_4H5YEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_qDb_4X5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qDb_435YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FLBiQnppEeqMpJXtwtppeQ" x="800" y="-700"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qDb_4n5YEeqCy67P6xy4tg" x="800" y="-700"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_FLp0YHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_FLp0YXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FLp0Y3ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_qEGHMH5YEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_qEGHMX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qEGHM35YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_6bbCwLqLEemx9sMHf8Tuig"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FLp0YnppEeqMpJXtwtppeQ" x="180" y="-380"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qEGHMn5YEeqCy67P6xy4tg" x="180" y="-380"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_FL8IQ3ppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_FL8IRHppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FL8IRnppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_qEWl435YEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_qEWl5H5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qEWl5n5YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Interface" href="TapiStreaming.uml#_dBX4MLqOEemx9sMHf8Tuig"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FL8IRXppEeqMpJXtwtppeQ" x="420" y="-700"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qEWl5X5YEeqCy67P6xy4tg" x="420" y="-700"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_FMVw4HppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_FMVw4XppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FMVw43ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_qEvncH5YEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_qEvncX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qEvnc35YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_qFJloLqQEemx9sMHf8Tuig"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FMVw4nppEeqMpJXtwtppeQ" x="-160" y="-180"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qEvncn5YEeqCy67P6xy4tg" x="-160" y="-180"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_FM05EHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_FM05EXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FM05E3ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_qFPWsH5YEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_qFPWsX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qFPWs35YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_MJPYYBXeEeqAktXlUG_iEw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FM05EnppEeqMpJXtwtppeQ" x="-164" y="20"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qFPWsn5YEeqCy67P6xy4tg" x="-164" y="20"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_FNCUcHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_FNCUcXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FNC7gHppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_qFeAMH5YEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_qFeAMX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qFeAM35YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiStreaming.uml#_5Xt9oBXeEeqAktXlUG_iEw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FNCUcnppEeqMpJXtwtppeQ" x="-164" y="-80"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qFeAMn5YEeqCy67P6xy4tg" x="-164" y="-80"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_FNPIwHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_FNPIwXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FNPIw3ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_qFqNcH5YEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_qFqNcX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qFqNc35YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Interface" href="TapiStreaming.uml#_S1CbEBy6EeqCeNa5GcKdyg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FNPIwnppEeqMpJXtwtppeQ" y="-700"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qFqNcn5YEeqCy67P6xy4tg" y="-700"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_FNnjQHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_FNnjQXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FNnjQ3ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_qGALsH5YEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_qGALsX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qGALs35YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_jdeiEBy8EeqCeNa5GcKdyg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FNnjQnppEeqMpJXtwtppeQ" x="800" y="-540"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qGALsn5YEeqCy67P6xy4tg" x="800" y="-540"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_FN3a4HppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_FN3a4XppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FN3a43ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_qGNAAH5YEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_qGNAAX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qGNAA35YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiStreaming.uml#_01YpEBy8EeqCeNa5GcKdyg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FN3a4nppEeqMpJXtwtppeQ" x="800" y="-640"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qGNAAn5YEeqCy67P6xy4tg" x="800" y="-640"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_FN-voHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_FN-voXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FN-vo3ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_qGR4gH5YEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_qGR4gX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qGR4g35YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiStreaming.uml#_a-lNsBy9EeqCeNa5GcKdyg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FN-vonppEeqMpJXtwtppeQ" x="800" y="-640"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qGR4gn5YEeqCy67P6xy4tg" x="800" y="-640"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_FOVU8HppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_FOVU8XppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FOVU83ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_qGpE4H5YEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_qGpE4X5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qGpE435YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_R-mlEBXlEeqAktXlUG_iEw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FOVU8nppEeqMpJXtwtppeQ" x="800" y="-380"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qGpE4n5YEeqCy67P6xy4tg" x="800" y="-380"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_FOz2EHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_FOz2EXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FOz2E3ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_qHFw0H5YEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_qHFw0X5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qHFw035YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_B0Zw4B-1EeqCeNa5GcKdyg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FOz2EnppEeqMpJXtwtppeQ" x="320" y="360"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qHFw0n5YEeqCy67P6xy4tg" x="320" y="360"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_FO-OIHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_FO-OIXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FO-OI3ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_qHTzQH5YEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_qHTzQX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qHTzQ35YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiStreaming.uml#_sBHOQB-1EeqCeNa5GcKdyg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FO-OInppEeqMpJXtwtppeQ" x="320" y="260"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qHTzQn5YEeqCy67P6xy4tg" x="320" y="260"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_FPRJEHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_FPRJEXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FPRJE3ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_qHpKcH5YEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_qHpKcX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qHpxgH5YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_4ZR50G31EemRDKXaAompzQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FPRJEnppEeqMpJXtwtppeQ" x="320" y="180"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qHpKcn5YEeqCy67P6xy4tg" x="320" y="180"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_FPbhIHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_FPbhIXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FPbhI3ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_qH1XsH5YEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_qH1XsX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qH1-wH5YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiStreaming.uml#_yXZTUC45EeqsBLPUmmYf3g"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FPbhInppEeqMpJXtwtppeQ" x="320" y="80"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qH1Xsn5YEeqCy67P6xy4tg" x="320" y="80"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_FPqKoHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_FPqKoXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FPqKo3ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_qIGdcH5YEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_qIGdcX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qIGdc35YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_3Uj4oD0mEeqNzoiCK4mkvg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FPqKonppEeqMpJXtwtppeQ" x="40" y="20"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qIGdcn5YEeqCy67P6xy4tg" x="40" y="20"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_FP1JwHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_FP1JwXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FP1Jw3ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_qIPnYH5YEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_qIPnYX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qIPnY35YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiStreaming.uml#_wYS0oD0nEeqNzoiCK4mkvg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FP1JwnppEeqMpJXtwtppeQ" x="40" y="-80"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_qIPnYn5YEeqCy67P6xy4tg" x="40" y="-80"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_O8lDGUHbEeqO_YO5cZovrw" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_O8lDGkHbEeqO_YO5cZovrw"/>
@@ -3928,305 +3842,305 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_O8lo7UHbEeqO_YO5cZovrw" id="(0.3314917127071823,0.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_O8lo7kHbEeqO_YO5cZovrw" id="(0.7734806629834254,1.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_FISXVHppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_O8hXUUHbEeqO_YO5cZovrw" target="_FISXUHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_FISXVXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FISXWXppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_qAsN4H5YEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_O8hXUUHbEeqO_YO5cZovrw" target="_qArm0H5YEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_qAsN4X5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qAsN5X5YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_eXlBcGWwEemRDKXaAompzQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FISXVnppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FISXV3ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FISXWHppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qAsN4n5YEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qAsN435YEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qAsN5H5YEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_FIfLoXppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_O8lDHEHbEeqO_YO5cZovrw" target="_FIekkHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_FIfLonppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FIfLpnppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_qA2l9H5YEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_O8lDHEHbEeqO_YO5cZovrw" target="_qA2l8H5YEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_qA2l9X5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qA2l-X5YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiStreaming.uml#_X3gNYGW1EemRDKXaAompzQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FIfLo3ppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FIfLpHppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FIfLpXppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qA2l9n5YEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qA2l935YEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qA2l-H5YEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_FIlSRHppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_O8lDNkHbEeqO_YO5cZovrw" target="_FIlSQHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_FIlSRXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FIlSSXppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_qA9ToX5YEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_O8lDNkHbEeqO_YO5cZovrw" target="_qA8skH5YEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_qA9Ton5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qA9Tpn5YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiStreaming.uml#_YZxM8GW1EemRDKXaAompzQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FIlSRnppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FIlSR3ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FIlSSHppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qA9To35YEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qA9TpH5YEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qA9TpX5YEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_FI1w9HppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_O8h-rkHbEeqO_YO5cZovrw" target="_FI1w8HppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_FI1w9XppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FI1w-XppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_qBNyVH5YEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_O8h-rkHbEeqO_YO5cZovrw" target="_qBNyUH5YEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_qBNyVX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qBNyWX5YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_im_oMGWwEemRDKXaAompzQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FI1w9nppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FI1w93ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FI1w-HppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qBNyVn5YEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qBNyV35YEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qBNyWH5YEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_FJLvMHppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_O8h_90HbEeqO_YO5cZovrw" target="_FJLIIHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_FJLvMXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FJLvNXppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_qBhUVH5YEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_O8h_90HbEeqO_YO5cZovrw" target="_qBhUUH5YEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_qBhUVX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qBhUWX5YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_lKL9sGWwEemRDKXaAompzQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FJLvMnppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FJLvM3ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FJLvNHppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qBhUVn5YEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qBhUV35YEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qBhUWH5YEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_FJfRNHppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_O8iA7EHbEeqO_YO5cZovrw" target="_FJfRMHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_FJfRNXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FJfROXppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_qB02VH5YEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_O8iA7EHbEeqO_YO5cZovrw" target="_qB02UH5YEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_qB02VX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qB1dYH5YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_2U15kGW1EemRDKXaAompzQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FJfRNnppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FJfRN3ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FJfROHppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qB02Vn5YEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qB02V35YEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qB02WH5YEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_FJn0FHppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_O8lDUEHbEeqO_YO5cZovrw" target="_FJn0EHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_FJn0FXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FJn0GXppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_qB_OZH5YEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_O8lDUEHbEeqO_YO5cZovrw" target="_qB_OYH5YEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_qB_OZX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qB_OaX5YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiStreaming.uml#_i2jWAG3mEemRDKXaAompzQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FJn0FnppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FJn0F3ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FJn0GHppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qB_OZn5YEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qB_OZ35YEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qB_OaH5YEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_FJvI1HppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_O8iBPEHbEeqO_YO5cZovrw" target="_FJvI0HppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_FJvI1XppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FJvI2XppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_qCHKNH5YEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_O8iBPEHbEeqO_YO5cZovrw" target="_qCHKMH5YEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_qCHKNX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qCHKOX5YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Signal" href="TapiStreaming.uml#_X9ay8LqKEemx9sMHf8Tuig"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FJvI1nppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FJvI13ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FJvI2HppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qCHKNn5YEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qCHKN35YEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qCHKOH5YEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_FJ0oZHppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_O8lDYkHbEeqO_YO5cZovrw" target="_FJ0oYHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_FJ0oZXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FJ0oaXppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_qCN35H5YEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_O8lDYkHbEeqO_YO5cZovrw" target="_qCN34H5YEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_qCN35X5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qCN36X5YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiStreaming.uml#_s9prgLqKEemx9sMHf8Tuig"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FJ0oZnppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FJ0oZ3ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FJ0oaHppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qCN35n5YEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qCN3535YEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qCN36H5YEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_FKD49HppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_O8iBjEHbEeqO_YO5cZovrw" target="_FKD48HppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_FKD49XppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FKEgAnppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_qChZ5H5YEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_O8iBjEHbEeqO_YO5cZovrw" target="_qChZ4H5YEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_qChZ5X5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qChZ6X5YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_gv58QLqKEemx9sMHf8Tuig"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FKD49nppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FKEgAHppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FKEgAXppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qChZ5n5YEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qChZ535YEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qChZ6H5YEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_FKORBHppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_O8lDfEHbEeqO_YO5cZovrw" target="_FKORAHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_FKORBXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FKORCXppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_qCrK5H5YEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_O8lDfEHbEeqO_YO5cZovrw" target="_qCrK4H5YEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_qCrK5X5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qCrK6X5YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiStreaming.uml#_5n-CALqKEemx9sMHf8Tuig"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FKORBnppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FKORB3ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FKORCHppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qCrK5n5YEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qCrK535YEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qCrK6H5YEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_FKUXpHppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_O8lDikHbEeqO_YO5cZovrw" target="_FKUXoHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_FKUXpXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FKUXqXppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_qCwqc35YEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_O8lDikHbEeqO_YO5cZovrw" target="_qCwDYH5YEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_qCwqdH5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qCwqeH5YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiStreaming.uml#_AiVEsLqOEemx9sMHf8Tuig"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FKUXpnppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FKUXp3ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FKUXqHppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qCwqdX5YEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qCwqdn5YEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qCwqd35YEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_FKcTdHppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_O8lDpEHbEeqO_YO5cZovrw" target="_FKcTcHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_FKcTdXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FKc6gHppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_qC3YJH5YEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_O8lDpEHbEeqO_YO5cZovrw" target="_qC3YIH5YEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_qC3YJX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qC3YKX5YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiStreaming.uml#__-BWYLqQEemx9sMHf8Tuig"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FKcTdnppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FKcTd3ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FKcTeHppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qC3YJn5YEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qC3YJ35YEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qC3YKH5YEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_FLBiRHppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_O8iCIUHbEeqO_YO5cZovrw" target="_FLBiQHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_FLBiRXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FLBiSXppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_qDb_5H5YEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_O8iCIUHbEeqO_YO5cZovrw" target="_qDb_4H5YEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_qDb_5X5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qDb_6X5YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FLBiRnppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FLBiR3ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FLBiSHppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qDb_5n5YEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qDb_535YEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qDb_6H5YEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_FLp0ZHppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_O8iCdUHbEeqO_YO5cZovrw" target="_FLp0YHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_FLp0ZXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FLp0aXppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_qEGHNH5YEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_O8iCdUHbEeqO_YO5cZovrw" target="_qEGHMH5YEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_qEGHNX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qEGuQX5YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_6bbCwLqLEemx9sMHf8Tuig"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FLp0ZnppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FLp0Z3ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FLp0aHppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qEGHNn5YEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qEGHN35YEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qEGuQH5YEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_FL8IR3ppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_O8imckHbEeqO_YO5cZovrw" target="_FL8IQ3ppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_FL8ISHppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FL8ITHppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_qEWl535YEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_O8imckHbEeqO_YO5cZovrw" target="_qEWl435YEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_qEWl6H5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qEXM8H5YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Interface" href="TapiStreaming.uml#_dBX4MLqOEemx9sMHf8Tuig"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FL8ISXppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FL8ISnppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FL8IS3ppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qEWl6X5YEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qEWl6n5YEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qEWl635YEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_FMWX8HppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_O8imw0HbEeqO_YO5cZovrw" target="_FMVw4HppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_FMWX8XppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FMWX9XppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_qEvndH5YEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_O8imw0HbEeqO_YO5cZovrw" target="_qEvncH5YEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_qEvndX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qEvneX5YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_qFJloLqQEemx9sMHf8Tuig"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FMWX8nppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FMWX83ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FMWX9HppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qEvndn5YEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qEvnd35YEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qEvneH5YEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_FM05FHppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_O8jMh0HbEeqO_YO5cZovrw" target="_FM05EHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_FM05FXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FM05GXppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_qFPWtH5YEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_O8jMh0HbEeqO_YO5cZovrw" target="_qFPWsH5YEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_qFPWtX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qFPWuX5YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_MJPYYBXeEeqAktXlUG_iEw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FM05FnppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FM05F3ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FM05GHppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qFPWtn5YEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qFPWt35YEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qFPWuH5YEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_FNC7gXppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_O8lD1UHbEeqO_YO5cZovrw" target="_FNCUcHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_FNC7gnppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FNC7hnppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_qFeANH5YEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_O8lD1UHbEeqO_YO5cZovrw" target="_qFeAMH5YEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_qFeANX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qFenQX5YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiStreaming.uml#_5Xt9oBXeEeqAktXlUG_iEw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FNC7g3ppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FNC7hHppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FNC7hXppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qFeANn5YEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qFeAN35YEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qFenQH5YEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_FNPIxHppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_O8jNNUHbEeqO_YO5cZovrw" target="_FNPIwHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_FNPIxXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FNPIyXppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_qFqNdH5YEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_O8jNNUHbEeqO_YO5cZovrw" target="_qFqNcH5YEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_qFqNdX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qFqNeX5YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Interface" href="TapiStreaming.uml#_S1CbEBy6EeqCeNa5GcKdyg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FNPIxnppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FNPIx3ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FNPIyHppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qFqNdn5YEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qFqNd35YEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qFqNeH5YEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_FNnjRHppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_O8jNcEHbEeqO_YO5cZovrw" target="_FNnjQHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_FNnjRXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FNoKUXppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_qGALtH5YEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_O8jNcEHbEeqO_YO5cZovrw" target="_qGALsH5YEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_qGALtX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qGALuX5YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_jdeiEBy8EeqCeNa5GcKdyg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FNnjRnppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FNnjR3ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FNoKUHppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qGALtn5YEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qGALt35YEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qGALuH5YEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_FN3a5HppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_O8lD40HbEeqO_YO5cZovrw" target="_FN3a4HppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_FN3a5XppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FN3a6XppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_qGNABH5YEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_O8lD40HbEeqO_YO5cZovrw" target="_qGNAAH5YEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_qGNABX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qGNACX5YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiStreaming.uml#_01YpEBy8EeqCeNa5GcKdyg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FN3a5nppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FN3a53ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FN3a6HppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qGNABn5YEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qGNAB35YEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qGNACH5YEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_FN-vpHppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_O8lECkHbEeqO_YO5cZovrw" target="_FN-voHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_FN-vpXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FN-vqXppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_qGR4hH5YEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_O8lECkHbEeqO_YO5cZovrw" target="_qGR4gH5YEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_qGR4hX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qGR4iX5YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiStreaming.uml#_a-lNsBy9EeqCeNa5GcKdyg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FN-vpnppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FN-vp3ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FN-vqHppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qGR4hn5YEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qGR4h35YEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qGR4iH5YEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_FOV8AHppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_O8jN2UHbEeqO_YO5cZovrw" target="_FOVU8HppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_FOV8AXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FOV8BXppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_qGpE5H5YEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_O8jN2UHbEeqO_YO5cZovrw" target="_qGpE4H5YEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_qGpE5X5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qGpE6X5YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_R-mlEBXlEeqAktXlUG_iEw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FOV8AnppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FOV8A3ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FOV8BHppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qGpE5n5YEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qGpE535YEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qGpE6H5YEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_FOz2FHppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_O8jPHkHbEeqO_YO5cZovrw" target="_FOz2EHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_FOz2FXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FOz2GXppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_qHGX4H5YEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_O8jPHkHbEeqO_YO5cZovrw" target="_qHFw0H5YEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_qHGX4X5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qHGX5X5YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_B0Zw4B-1EeqCeNa5GcKdyg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FOz2FnppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FOz2F3ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FOz2GHppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qHGX4n5YEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qHGX435YEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qHGX5H5YEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_FO-OJHppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_O8lEJEHbEeqO_YO5cZovrw" target="_FO-OIHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_FO-1MHppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FO-1NHppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_qHTzRH5YEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_O8lEJEHbEeqO_YO5cZovrw" target="_qHTzQH5YEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_qHTzRX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qHTzSX5YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiStreaming.uml#_sBHOQB-1EeqCeNa5GcKdyg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FO-1MXppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FO-1MnppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FO-1M3ppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qHTzRn5YEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qHTzR35YEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qHTzSH5YEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_FPRJFHppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_O8jPs0HbEeqO_YO5cZovrw" target="_FPRJEHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_FPRJFXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FPRJGXppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_qHpxgX5YEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_O8jPs0HbEeqO_YO5cZovrw" target="_qHpKcH5YEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_qHpxgn5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qHpxhn5YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_4ZR50G31EemRDKXaAompzQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FPRJFnppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FPRJF3ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FPRJGHppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qHpxg35YEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qHpxhH5YEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qHpxhX5YEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_FPbhJHppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_O8lowUHbEeqO_YO5cZovrw" target="_FPbhIHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_FPbhJXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FPbhKXppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_qH1-wX5YEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_O8lowUHbEeqO_YO5cZovrw" target="_qH1XsH5YEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_qH1-wn5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qH1-xn5YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiStreaming.uml#_yXZTUC45EeqsBLPUmmYf3g"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FPbhJnppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FPbhJ3ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FPbhKHppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qH1-w35YEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qH1-xH5YEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qH1-xX5YEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_FPqKpHppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_O8kaxUHbEeqO_YO5cZovrw" target="_FPqKoHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_FPqKpXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FPqKqXppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_qIGddH5YEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_O8kaxUHbEeqO_YO5cZovrw" target="_qIGdcH5YEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_qIGddX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qIGdeX5YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_3Uj4oD0mEeqNzoiCK4mkvg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FPqKpnppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FPqKp3ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FPqKqHppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qIGddn5YEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qIGdd35YEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qIGdeH5YEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_FP1JxHppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_O8lo40HbEeqO_YO5cZovrw" target="_FP1JwHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_FP1JxXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FP1JyXppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_qIPnZH5YEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_O8lo40HbEeqO_YO5cZovrw" target="_qIPnYH5YEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_qIPnZX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_qIPnaX5YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiStreaming.uml#_wYS0oD0nEeqNzoiCK4mkvg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FP1JxnppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FP1Jx3ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FP1JyHppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_qIPnZn5YEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qIPnZ35YEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_qIPnaH5YEeqCy67P6xy4tg"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_bjXc8HlbEeqVN_GB3rPx7g" type="PapyrusUMLClassDiagram" name="StreamingAugmentationForStreaming" measurementUnit="Pixel">
@@ -4428,109 +4342,109 @@
       <element xmi:type="uml:Class" href="TapiStreaming.uml#_qFJloLqQEemx9sMHf8Tuig"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_zrK2gXlzEeqVN_GB3rPx7g" x="880" y="-200" width="221"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_FSW5UHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_FSW5UXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FSW5U3ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_nyB98H5YEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_nyB98X5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_nyB9835YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_4ZR50G31EemRDKXaAompzQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FSW5UnppEeqMpJXtwtppeQ" x="1080" y="160"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nyB98n5YEeqCy67P6xy4tg" x="1080" y="160"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_FSfcMHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_FSfcMXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FSfcM3ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_nyTDsH5YEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_nyTDsX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_nyTDs35YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiStreaming.uml#_yXZTUC45EeqsBLPUmmYf3g"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FSfcMnppEeqMpJXtwtppeQ" x="1080" y="60"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nyTDsn5YEeqCy67P6xy4tg" x="1080" y="60"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_FSs3kHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_FSs3kXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FSs3k3ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_nyvvoH5YEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_nyvvoX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_nyvvo35YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_2U15kGW1EemRDKXaAompzQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FSs3knppEeqMpJXtwtppeQ" x="1080" y="40"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nyvvon5YEeqCy67P6xy4tg" x="1080" y="40"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_FS1acHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_FS1acXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FS1ac3ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_nzA1YH5YEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_nzA1YX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_nzA1Y35YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiStreaming.uml#_i2jWAG3mEemRDKXaAompzQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FS1acnppEeqMpJXtwtppeQ" x="1080" y="-60"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nzA1Yn5YEeqCy67P6xy4tg" x="1080" y="-60"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_FTDc4HppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_FTDc4XppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FTDc43ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_nzdhUH5YEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_nzdhUX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_nzdhU35YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_lKL9sGWwEemRDKXaAompzQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FTDc4nppEeqMpJXtwtppeQ" x="260" y="-320"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_nzdhUn5YEeqCy67P6xy4tg" x="260" y="-320"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_FTbQUHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_FTbQUXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FTbQU3ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_n0QLgH5YEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_n0QLgX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_n0QLg35YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_It0sYEG-EeWMO5szP8dKiA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FTbQUnppEeqMpJXtwtppeQ" x="1080" y="280"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_n0QLgn5YEeqCy67P6xy4tg" x="1080" y="280"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_FTjMIHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_FTjMIXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FTjMI3ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_n0hRQH5YEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_n0hRQX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_n0hRQ35YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiCommon.uml#_Fn71gHldEeqVN_GB3rPx7g"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FTjMInppEeqMpJXtwtppeQ" x="1080" y="180"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_n0hRQn5YEeqCy67P6xy4tg" x="1080" y="180"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_FTycsHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_FTycsXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FTycs3ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_n0-kQH5YEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_n0-kQX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_n0-kQ35YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_R-mlEBXlEeqAktXlUG_iEw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FTycsnppEeqMpJXtwtppeQ" x="1080" y="-320"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_n0-kQn5YEeqCy67P6xy4tg" x="1080" y="-320"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_FT5xcHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_FT5xcXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FT5xc3ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_n1Q4IH5YEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_n1Q4IX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_n1Q4I35YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiStreaming.uml#_7LB6UHlzEeqVN_GB3rPx7g"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FT5xcnppEeqMpJXtwtppeQ" x="1080" y="-420"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_n1Q4In5YEeqCy67P6xy4tg" x="1080" y="-420"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_FUIa8HppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_FUIa8XppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FUIa83ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_n1s9AH5YEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_n1s9AX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_n1s9A35YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_6bbCwLqLEemx9sMHf8Tuig"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FUIa8nppEeqMpJXtwtppeQ" x="1080" y="-80"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_n1s9An5YEeqCy67P6xy4tg" x="1080" y="-80"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_FUQWwHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_FUQWwXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FUQWw3ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_n180oH5YEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_n180oX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_n19bsH5YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiStreaming.uml#_-KswcHlzEeqVN_GB3rPx7g"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FUQWwnppEeqMpJXtwtppeQ" x="1080" y="-180"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_n180on5YEeqCy67P6xy4tg" x="1080" y="-180"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_FUeZMHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_FUeZMXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FUeZM3ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_n2Y5gH5YEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_n2Y5gX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_n2Y5g35YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_qFJloLqQEemx9sMHf8Tuig"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FUeZMnppEeqMpJXtwtppeQ" x="1080" y="-200"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_n2Y5gn5YEeqCy67P6xy4tg" x="1080" y="-200"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_FUnjIHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_FUnjIXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FUoKMHppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_n2tpoH5YEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_n2tpoX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_n2tpo35YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiStreaming.uml#_8WlugHlzEeqVN_GB3rPx7g"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FUnjInppEeqMpJXtwtppeQ" x="1080" y="-300"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_n2tpon5YEeqCy67P6xy4tg" x="1080" y="-300"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_bjXc8XlbEeqVN_GB3rPx7g" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_bjXc8nlbEeqVN_GB3rPx7g"/>
@@ -4653,135 +4567,135 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-PtzUHlzEeqVN_GB3rPx7g" id="(0.0,0.4)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_-PtzUXlzEeqVN_GB3rPx7g" id="(1.0,0.3883495145631068)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_FSW5VHppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_lcoBEHlbEeqVN_GB3rPx7g" target="_FSW5UHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_FSW5VXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FSW5WXppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_nyB99H5YEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_lcoBEHlbEeqVN_GB3rPx7g" target="_nyB98H5YEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_nyB99X5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_nyClAn5YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_4ZR50G31EemRDKXaAompzQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FSW5VnppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FSW5V3ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FSW5WHppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nyB99n5YEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nyClAH5YEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nyClAX5YEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_FSfcNHppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_lcs5p3lbEeqVN_GB3rPx7g" target="_FSfcMHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_FSfcNXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FSfcOXppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_nyTDtH5YEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_lcs5p3lbEeqVN_GB3rPx7g" target="_nyTDsH5YEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_nyTDtX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_nyTDuX5YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiStreaming.uml#_yXZTUC45EeqsBLPUmmYf3g"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FSfcNnppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FSfcN3ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FSfcOHppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nyTDtn5YEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nyTDt35YEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nyTDuH5YEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_FSs3lHppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_lcrEYHlbEeqVN_GB3rPx7g" target="_FSs3kHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_FSs3lXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FSs3mXppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_nyvvpH5YEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_lcrEYHlbEeqVN_GB3rPx7g" target="_nyvvoH5YEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_nyvvpX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_nyvvqX5YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_2U15kGW1EemRDKXaAompzQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FSs3lnppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FSs3l3ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FSs3mHppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nyvvpn5YEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nyvvp35YEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nyvvqH5YEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_FS1adHppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_lcs5kHlbEeqVN_GB3rPx7g" target="_FS1acHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_FS1adXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FS1aeXppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_nzA1ZH5YEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_lcs5kHlbEeqVN_GB3rPx7g" target="_nzA1YH5YEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_nzA1ZX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_nzA1aX5YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiStreaming.uml#_i2jWAG3mEemRDKXaAompzQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FS1adnppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FS1ad3ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FS1aeHppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nzA1Zn5YEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nzA1Z35YEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nzA1aH5YEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_FTDc5HppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_lcrEnXlbEeqVN_GB3rPx7g" target="_FTDc4HppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_FTDc5XppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FTDc6XppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_nzeIYH5YEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_lcrEnXlbEeqVN_GB3rPx7g" target="_nzdhUH5YEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_nzeIYX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_nzeIZX5YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_lKL9sGWwEemRDKXaAompzQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FTDc5nppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FTDc53ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FTDc6HppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_nzeIYn5YEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nzeIY35YEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_nzeIZH5YEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_FTbQVHppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_dn3O0HlcEeqVN_GB3rPx7g" target="_FTbQUHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_FTbQVXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FTbQWXppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_n0QLhH5YEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_dn3O0HlcEeqVN_GB3rPx7g" target="_n0QLgH5YEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_n0QLhX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_n0QLiX5YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_It0sYEG-EeWMO5szP8dKiA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FTbQVnppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FTbQV3ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FTbQWHppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_n0QLhn5YEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_n0QLh35YEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_n0QLiH5YEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_FTjMJHppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_Fn9DoHldEeqVN_GB3rPx7g" target="_FTjMIHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_FTjMJXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FTjMKXppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_n0hRRH5YEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_Fn9DoHldEeqVN_GB3rPx7g" target="_n0hRQH5YEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_n0hRRX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_n0h4Un5YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiCommon.uml#_Fn71gHldEeqVN_GB3rPx7g"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FTjMJnppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FTjMJ3ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FTjMKHppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_n0hRRn5YEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_n0h4UH5YEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_n0h4UX5YEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_FTyctHppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_zlr5kHlzEeqVN_GB3rPx7g" target="_FTycsHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_FTyctXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FTycuXppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_n0-kRH5YEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_zlr5kHlzEeqVN_GB3rPx7g" target="_n0-kQH5YEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_n0-kRX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_n0-kSX5YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_R-mlEBXlEeqAktXlUG_iEw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FTyctnppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FTyct3ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FTycuHppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_n0-kRn5YEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_n0-kR35YEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_n0-kSH5YEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_FT5xdHppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_7LDvgHlzEeqVN_GB3rPx7g" target="_FT5xcHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_FT5xdXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FT5xeXppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_n1Q4JH5YEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_7LDvgHlzEeqVN_GB3rPx7g" target="_n1Q4IH5YEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_n1Q4JX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_n1RfMH5YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiStreaming.uml#_7LB6UHlzEeqVN_GB3rPx7g"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FT5xdnppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FT5xd3ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FT5xeHppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_n1Q4Jn5YEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_n1Q4J35YEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_n1Q4KH5YEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_FUIa9HppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_zoadcHlzEeqVN_GB3rPx7g" target="_FUIa8HppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_FUIa9XppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FUIa-XppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_n1s9BH5YEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_zoadcHlzEeqVN_GB3rPx7g" target="_n1s9AH5YEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_n1s9BX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_n1s9CX5YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_6bbCwLqLEemx9sMHf8Tuig"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FUIa9nppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FUIa93ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FUIa-HppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_n1s9Bn5YEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_n1s9B35YEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_n1s9CH5YEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_FUQWxHppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_-KtXgHlzEeqVN_GB3rPx7g" target="_FUQWwHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_FUQWxXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FUQWyXppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_n19bsX5YEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_-KtXgHlzEeqVN_GB3rPx7g" target="_n180oH5YEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_n19bsn5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_n19btn5YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiStreaming.uml#_-KswcHlzEeqVN_GB3rPx7g"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FUQWxnppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FUQWx3ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FUQWyHppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_n19bs35YEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_n19btH5YEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_n19btX5YEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_FUeZNHppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_zrK2gHlzEeqVN_GB3rPx7g" target="_FUeZMHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_FUeZNXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FUeZOXppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_n2Y5hH5YEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_zrK2gHlzEeqVN_GB3rPx7g" target="_n2Y5gH5YEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_n2Y5hX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_n2Y5iX5YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_qFJloLqQEemx9sMHf8Tuig"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FUeZNnppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FUeZN3ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FUeZOHppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_n2Y5hn5YEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_n2Y5h35YEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_n2Y5iH5YEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_FUoKMXppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_8WmVkHlzEeqVN_GB3rPx7g" target="_FUnjIHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_FUoKMnppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FUoKNnppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_n2tppH5YEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_8WmVkHlzEeqVN_GB3rPx7g" target="_n2tpoH5YEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_n2tppX5YEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_n2uQsH5YEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiStreaming.uml#_8WlugHlzEeqVN_GB3rPx7g"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FUoKM3ppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FUoKNHppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FUoKNXppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_n2tppn5YEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_n2tpp35YEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_n2tpqH5YEeqCy67P6xy4tg"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_znJJwHmBEeqVN_GB3rPx7g" type="PapyrusUMLClassDiagram" name="CommonAugmentationForStreaming" measurementUnit="Pixel">

--- a/UML/TapiStreaming.notation
+++ b/UML/TapiStreaming.notation
@@ -695,20 +695,6 @@
           <element xmi:type="uml:Property" href="TapiStreaming.uml#_wOPD0MEfEemNuM6W9x-XhQ"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_z5_loB-3EeqCeNa5GcKdyg"/>
         </children>
-        <children xmi:type="notation:Shape" xmi:id="_Qfq3sDltEeqNzoiCK4mkvg" type="Property_ClassAttributeLabel">
-          <children xmi:type="notation:DecorationNode" xmi:id="_QgVmEDltEeqNzoiCK4mkvg" visible="false" type="StereotypeLabel">
-            <styles xmi:type="notation:StringValueStyle" xmi:id="_QgVmETltEeqNzoiCK4mkvg" name="stereotype" stringValue="OpenModel_Profile::OpenModelAttribute"/>
-            <element xmi:type="uml:Stereotype" href="UmlProfiles/OpenModelProfile/OpenModel_Profile.profile.uml#_36ZCQHBgEd6FKu9XX1078A"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QgVmEjltEeqNzoiCK4mkvg"/>
-          </children>
-          <children xmi:type="notation:DecorationNode" xmi:id="_QgYCUjltEeqNzoiCK4mkvg" visible="false" type="StereotypeLabel">
-            <styles xmi:type="notation:StringValueStyle" xmi:id="_QgYCUzltEeqNzoiCK4mkvg" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceModelAttribute"/>
-            <element xmi:type="uml:Stereotype" href="UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_ECvBANcqEea1ncO03M1x2w"/>
-            <layoutConstraint xmi:type="notation:Bounds" xmi:id="_QgYCVDltEeqNzoiCK4mkvg"/>
-          </children>
-          <element xmi:type="uml:Property" href="TapiStreaming.uml#_O6m-YDltEeqNzoiCK4mkvg"/>
-          <layoutConstraint xmi:type="notation:Location" xmi:id="_Qfq3sTltEeqNzoiCK4mkvg"/>
-        </children>
         <children xmi:type="notation:Shape" xmi:id="_z5_loR-3EeqCeNa5GcKdyg" type="Property_ClassAttributeLabel">
           <children xmi:type="notation:DecorationNode" xmi:id="_z5_loh-3EeqCeNa5GcKdyg" visible="false" type="StereotypeLabel">
             <styles xmi:type="notation:StringValueStyle" xmi:id="_z5_lox-3EeqCeNa5GcKdyg" name="stereotype" stringValue="OpenModel_Profile::OpenModelAttribute"/>

--- a/UML/TapiStreaming.notation
+++ b/UML/TapiStreaming.notation
@@ -1207,13 +1207,17 @@
           <element xmi:type="uml:EnumerationLiteral" href="TapiStreaming.uml#_UeJs0HiiEeqVN_GB3rPx7g"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_DdzUyXijEeqVN_GB3rPx7g"/>
         </children>
+        <children xmi:type="notation:Shape" xmi:id="_LPxZoIBhEeqCy67P6xy4tg" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiStreaming.uml#_LIBL0IBhEeqCy67P6xy4tg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_LPxZoYBhEeqCy67P6xy4tg"/>
+        </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_z6AMDB-3EeqCeNa5GcKdyg"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_z6AMDR-3EeqCeNa5GcKdyg"/>
         <styles xmi:type="notation:FilteringStyle" xmi:id="_z6AMDh-3EeqCeNa5GcKdyg"/>
         <layoutConstraint xmi:type="notation:Bounds" xmi:id="_z6AMDx-3EeqCeNa5GcKdyg"/>
       </children>
       <element xmi:type="uml:Enumeration" href="TapiStreaming.uml#_i0UJ8By0EeqCeNa5GcKdyg"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_z6AMEx-3EeqCeNa5GcKdyg" x="-460" y="-20" width="261" height="821"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_z6AMEx-3EeqCeNa5GcKdyg" x="-460" y="-20" width="261" height="841"/>
     </children>
     <children xmi:type="notation:Shape" xmi:id="_z6AMFB-3EeqCeNa5GcKdyg" type="Interface_Shape">
       <children xmi:type="notation:DecorationNode" xmi:id="_z6AMFR-3EeqCeNa5GcKdyg" type="Interface_NameLabel"/>
@@ -1772,6 +1776,10 @@
           <element xmi:type="uml:EnumerationLiteral" href="TapiStreaming.uml#_xloysHVoEeqfmpW3vMmyvQ"/>
           <layoutConstraint xmi:type="notation:Location" xmi:id="_xsK4gXVoEeqfmpW3vMmyvQ"/>
         </children>
+        <children xmi:type="notation:Shape" xmi:id="_j7SGkIBgEeqCy67P6xy4tg" type="EnumerationLiteral_LiteralLabel">
+          <element xmi:type="uml:EnumerationLiteral" href="TapiStreaming.uml#_GPnH4IBgEeqCy67P6xy4tg"/>
+          <layoutConstraint xmi:type="notation:Location" xmi:id="_j7SGkYBgEeqCy67P6xy4tg"/>
+        </children>
         <styles xmi:type="notation:TitleStyle" xmi:id="_izOHQXVoEeqfmpW3vMmyvQ"/>
         <styles xmi:type="notation:SortingStyle" xmi:id="_izOHQnVoEeqfmpW3vMmyvQ"/>
         <styles xmi:type="notation:FilteringStyle" xmi:id="_izOHQ3VoEeqfmpW3vMmyvQ"/>
@@ -1792,245 +1800,245 @@
       <element xmi:type="uml:Constraint" href="TapiStreaming.uml#_8KcbEHjSEeqVN_GB3rPx7g"/>
       <layoutConstraint xmi:type="notation:Bounds" xmi:id="_8KdpMXjSEeqVN_GB3rPx7g" x="620" y="660"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_E6FjQHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_E6FjQXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E6FjQ3ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_ehpvcIBgEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ehpvcYBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ehqWgIBgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_eXlBcGWwEemRDKXaAompzQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_E6FjQnppEeqMpJXtwtppeQ" x="420" y="20"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ehpvcoBgEeqCy67P6xy4tg" x="420" y="20"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_E6SXkHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_E6SXkXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E6SXk3ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_eicZoIBgEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_eicZoYBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_eicZo4BgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiStreaming.uml#_X3gNYGW1EemRDKXaAompzQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_E6SXknppEeqMpJXtwtppeQ" x="420" y="-80"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_eicZooBgEeqCy67P6xy4tg" x="420" y="-80"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_E6X3IHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_E6X3IXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E6X3I3ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_eimxsIBgEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_eimxsYBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_einYwIBgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiStreaming.uml#_YZxM8GW1EemRDKXaAompzQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_E6X3InppEeqMpJXtwtppeQ" x="420" y="-80"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_eimxsoBgEeqCy67P6xy4tg" x="420" y="-80"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_E6nuwHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_E6nuwXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E6nuw3ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_ejGg8IBgEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ejGg8YBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ejHIAIBgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_im_oMGWwEemRDKXaAompzQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_E6nuwnppEeqMpJXtwtppeQ" x="280" y="240"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ejGg8oBgEeqCy67P6xy4tg" x="280" y="240"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_E7FBwHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_E7FBwXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E7FBw3ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_ej_RwIBgEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ej_RwYBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ej_Rw4BgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_lKL9sGWwEemRDKXaAompzQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_E7FBwnppEeqMpJXtwtppeQ" x="660" y="240"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ej_RwoBgEeqCy67P6xy4tg" x="660" y="240"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_E7ji4HppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_E7ji4XppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E7ji43ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_ekzxIIBgEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ekzxIYBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ekzxI4BgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_2U15kGW1EemRDKXaAompzQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_E7ji4nppEeqMpJXtwtppeQ" x="760" y="520"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ekzxIoBgEeqCy67P6xy4tg" x="760" y="520"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_E7ss0HppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_E7ss0XppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E7ss03ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_elIhQIBgEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_elIhQYBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_elIhQ4BgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiStreaming.uml#_i2jWAG3mEemRDKXaAompzQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_E7ss0nppEeqMpJXtwtppeQ" x="760" y="420"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_elIhQoBgEeqCy67P6xy4tg" x="760" y="420"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_E73E4HppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_E73E4XppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E73E43ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_elZnAIBgEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_elZnAYBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_elZnA4BgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Signal" href="TapiStreaming.uml#_X9ay8LqKEemx9sMHf8Tuig"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_E73E4nppEeqMpJXtwtppeQ" x="520" y="-160"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_elZnAoBgEeqCy67P6xy4tg" x="520" y="-160"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_E7_AsHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_E7_AsXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E7_As3ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_elnCYIBgEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_elnCYYBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_elnCY4BgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiStreaming.uml#_s9prgLqKEemx9sMHf8Tuig"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_E7_AsnppEeqMpJXtwtppeQ" x="520" y="-260"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_elnCYoBgEeqCy67P6xy4tg" x="520" y="-260"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_E8O4UHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_E8O4UXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E8O4U3ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_emAD8IBgEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_emAD8YBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_emAD84BgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_gv58QLqKEemx9sMHf8Tuig"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_E8O4UnppEeqMpJXtwtppeQ" x="120" y="-540"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_emAD8oBgEeqCy67P6xy4tg" x="120" y="-540"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_E8bFkHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_E8bFkXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E8bFk3ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_emU0EIBgEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_emU0EYBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_emU0E4BgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiStreaming.uml#_5n-CALqKEemx9sMHf8Tuig"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_E8bFknppEeqMpJXtwtppeQ" x="120" y="-640"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_emU0EoBgEeqCy67P6xy4tg" x="120" y="-640"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_E8fXAHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_E8fXAXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E8fXA3ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_ema6sIBgEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ema6sYBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ema6s4BgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiStreaming.uml#_AiVEsLqOEemx9sMHf8Tuig"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_E8fXAnppEeqMpJXtwtppeQ" x="120" y="-640"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ema6soBgEeqCy67P6xy4tg" x="120" y="-640"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_E8k2kHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_E8k2kXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E8ldoHppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_eml50IBgEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_eml50YBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_eml504BgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiStreaming.uml#__-BWYLqQEemx9sMHf8Tuig"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_E8k2knppEeqMpJXtwtppeQ" x="120" y="-640"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_eml50oBgEeqCy67P6xy4tg" x="120" y="-640"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_E9CJkHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_E9CJkXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E9CJk3ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_enc1cIBgEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_enc1cYBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_enc1c4BgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_E9CJknppEeqMpJXtwtppeQ" x="960" y="-520"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_enc1coBgEeqCy67P6xy4tg" x="960" y="-520"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_E9bLIHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_E9bLIXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E9byMHppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_eoIx8IBgEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_eoIx8YBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_eoIx84BgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_6bbCwLqLEemx9sMHf8Tuig"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_E9bLInppEeqMpJXtwtppeQ" x="120" y="-340"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_eoIx8oBgEeqCy67P6xy4tg" x="120" y="-340"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_E9yXg3ppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_E9yXhHppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E9yXhnppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_eo_GgIBgEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_eo_GgYBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_eo_tkIBgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Interface" href="TapiStreaming.uml#_dBX4MLqOEemx9sMHf8Tuig"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_E9yXhXppEeqMpJXtwtppeQ" x="740" y="-640"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_eo_GgoBgEeqCy67P6xy4tg" x="740" y="-640"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_E-CPIHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_E-CPIXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E-CPI3ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_epbLYIBgEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_epbLYYBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_epbLY4BgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_qFJloLqQEemx9sMHf8Tuig"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_E-CPInppEeqMpJXtwtppeQ" x="-264" y="-220"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_epbLYoBgEeqCy67P6xy4tg" x="-264" y="-220"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_E--DQHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_E--DQXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E--DQ3ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_erEKIIBgEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_erEKIYBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_erEKI4BgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_MJPYYBXeEeqAktXlUG_iEw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_E--DQnppEeqMpJXtwtppeQ" x="100" y="80"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_erEKIoBgEeqCy67P6xy4tg" x="100" y="80"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_E_LeoHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_E_LeoXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E_Leo3ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_erg2EIBgEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_erg2EYBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_erg2E4BgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiStreaming.uml#_5Xt9oBXeEeqAktXlUG_iEw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_E_LeonppEeqMpJXtwtppeQ" x="100" y="-20"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_erg2EoBgEeqCy67P6xy4tg" x="100" y="-20"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_E_aIIHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_E_aIIXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E_aII3ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_er-wIIBgEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_er-wIYBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_er-wI4BgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Interface" href="TapiStreaming.uml#_S1CbEBy6EeqCeNa5GcKdyg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_E_aIInppEeqMpJXtwtppeQ" x="-260" y="-640"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_er-wIoBgEeqCy67P6xy4tg" x="-260" y="-640"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_E_scAHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_E_scAXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E_scA3ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_eso3cIBgEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_eso3cYBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_eso3c4BgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_jdeiEBy8EeqCeNa5GcKdyg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_E_scAnppEeqMpJXtwtppeQ" x="1020" y="-400"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_eso3coBgEeqCy67P6xy4tg" x="1020" y="-400"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_E_3bIHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_E_3bIXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E_3bI3ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_etGKcIBgEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_etGKcYBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_etGKc4BgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiStreaming.uml#_01YpEBy8EeqCeNa5GcKdyg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_E_3bInppEeqMpJXtwtppeQ" x="1020" y="-500"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_etGKcoBgEeqCy67P6xy4tg" x="1020" y="-500"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_E_7skHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_E_7skXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E_8ToHppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_etQigIBgEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_etQigYBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_etQig4BgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiStreaming.uml#_a-lNsBy9EeqCeNa5GcKdyg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_E_7sknppEeqMpJXtwtppeQ" x="1020" y="-500"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_etQigoBgEeqCy67P6xy4tg" x="1020" y="-500"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_FALkMHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_FALkMXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FALkM3ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_et0jMIBgEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_et0jMYBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_et0jM4BgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_R-mlEBXlEeqAktXlUG_iEw"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FALkMnppEeqMpJXtwtppeQ" x="1020" y="-200"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_et0jMoBgEeqCy67P6xy4tg" x="1020" y="-200"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_FAwzAHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_FAwzAXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FAxaEHppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_evEgYIBgEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_evEgYYBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_evEgY4BgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_B0Zw4B-1EeqCeNa5GcKdyg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FAwzAnppEeqMpJXtwtppeQ" x="400" y="800"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_evEgYoBgEeqCy67P6xy4tg" x="400" y="800"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_FA9nUHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_FA9nUXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FA9nU3ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_evdh8IBgEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_evdh8YBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_evdh84BgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiStreaming.uml#_sBHOQB-1EeqCeNa5GcKdyg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FA9nUnppEeqMpJXtwtppeQ" x="400" y="700"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_evdh8oBgEeqCy67P6xy4tg" x="400" y="700"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_FBM34HppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_FBM34XppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FBM343ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_ewD-4IBgEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ewD-4YBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ewD-44BgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_4ZR50G31EemRDKXaAompzQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FBM34nppEeqMpJXtwtppeQ" x="400" y="520"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ewD-4oBgEeqCy67P6xy4tg" x="400" y="520"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_FBnHkHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_FBnHkXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FBnHk3ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_ewvUUIBgEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_ewvUUYBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ewv7YIBgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiStreaming.uml#_yXZTUC45EeqsBLPUmmYf3g"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FBnHknppEeqMpJXtwtppeQ" x="400" y="420"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_ewvUUoBgEeqCy67P6xy4tg" x="400" y="420"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_FCDzgHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_FCDzgXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FCDzg3ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_exdtEIBgEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_exdtEYBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_exeUIIBgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_3Uj4oD0mEeqNzoiCK4mkvg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FCDzgnppEeqMpJXtwtppeQ" x="100" y="-60"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_exdtEoBgEeqCy67P6xy4tg" x="100" y="-60"/>
     </children>
-    <children xmi:type="notation:Shape" xmi:id="_FCOyoHppEeqMpJXtwtppeQ" type="StereotypeComment">
-      <styles xmi:type="notation:TitleStyle" xmi:id="_FCOyoXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FCOyo3ppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <children xmi:type="notation:Shape" xmi:id="_exxPEIBgEeqCy67P6xy4tg" type="StereotypeComment">
+      <styles xmi:type="notation:TitleStyle" xmi:id="_exxPEYBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_exxPE4BgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiStreaming.uml#_wYS0oD0nEeqNzoiCK4mkvg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_FCOyonppEeqMpJXtwtppeQ" x="100" y="-160"/>
+      <layoutConstraint xmi:type="notation:Bounds" xmi:id="_exxPEoBgEeqCy67P6xy4tg" x="100" y="-160"/>
     </children>
     <styles xmi:type="notation:StringValueStyle" xmi:id="_z6ANmB-3EeqCeNa5GcKdyg" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xmi:type="notation:DiagramStyle" xmi:id="_z6ANmR-3EeqCeNa5GcKdyg"/>
@@ -2449,305 +2457,305 @@
       <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xDRc4HjTEeqVN_GB3rPx7g" id="(0.06578947368421052,1.0)"/>
       <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_xDRc4XjTEeqVN_GB3rPx7g" id="(0.5257142857142857,1.0)"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_E6FjRHppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_z59u8R-3EeqCeNa5GcKdyg" target="_E6FjQHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_E6FjRXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E6FjSXppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_ehqWgYBgEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_z59u8R-3EeqCeNa5GcKdyg" target="_ehpvcIBgEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ehqWgoBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ehqWhoBgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_eXlBcGWwEemRDKXaAompzQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_E6FjRnppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E6FjR3ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E6FjSHppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ehqWg4BgEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ehqWhIBgEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ehqWhYBgEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_E6SXlHppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_z6ANmx-3EeqCeNa5GcKdyg" target="_E6SXkHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_E6SXlXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E6S-oHppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_eicZpIBgEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_z6ANmx-3EeqCeNa5GcKdyg" target="_eicZoIBgEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_eicZpYBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_eicZqYBgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiStreaming.uml#_X3gNYGW1EemRDKXaAompzQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_E6SXlnppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E6SXl3ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E6SXmHppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_eicZpoBgEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eicZp4BgEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eicZqIBgEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_E6X3JHppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_z6ANtR-3EeqCeNa5GcKdyg" target="_E6X3IHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_E6X3JXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E6X3KXppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_einYwYBgEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_z6ANtR-3EeqCeNa5GcKdyg" target="_eimxsIBgEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_einYwoBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ein_0IBgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiStreaming.uml#_YZxM8GW1EemRDKXaAompzQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_E6X3JnppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E6X3J3ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E6X3KHppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_einYw4BgEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_einYxIBgEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_einYxYBgEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_E6nuxHppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_z59vhh-3EeqCeNa5GcKdyg" target="_E6nuwHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_E6nuxXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E6oV0nppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_ejHIAYBgEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_z59vhh-3EeqCeNa5GcKdyg" target="_ejGg8IBgEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ejHIAoBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ejHIBoBgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_im_oMGWwEemRDKXaAompzQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_E6nuxnppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E6oV0HppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E6oV0XppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ejHIA4BgEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ejHIBIBgEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ejHIBYBgEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_E7FBxHppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_z5-XOR-3EeqCeNa5GcKdyg" target="_E7FBwHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_E7FBxXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E7FByXppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_ej_RxIBgEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_z5-XOR-3EeqCeNa5GcKdyg" target="_ej_RwIBgEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ej_RxYBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ej_RyYBgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_lKL9sGWwEemRDKXaAompzQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_E7FBxnppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E7FBx3ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E7FByHppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ej_RxoBgEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ej_Rx4BgEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ej_RyIBgEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_E7ji5HppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_z5-YLh-3EeqCeNa5GcKdyg" target="_E7ji4HppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_E7ji5XppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E7ji6XppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_ekzxJIBgEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_z5-YLh-3EeqCeNa5GcKdyg" target="_ekzxIIBgEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ekzxJYBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ekzxKYBgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_2U15kGW1EemRDKXaAompzQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_E7ji5nppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E7ji53ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E7ji6HppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ekzxJoBgEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ekzxJ4BgEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ekzxKIBgEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_E7ss1HppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_z6ANzx-3EeqCeNa5GcKdyg" target="_E7ss0HppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_E7ss1XppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E7tT4HppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_elIhRIBgEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_z6ANzx-3EeqCeNa5GcKdyg" target="_elIhQIBgEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_elIhRYBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_elIhSYBgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiStreaming.uml#_i2jWAG3mEemRDKXaAompzQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_E7ss1nppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E7ss13ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E7ss2HppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_elIhRoBgEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_elIhR4BgEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_elIhSIBgEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_E73E5HppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_z5-_eR-3EeqCeNa5GcKdyg" target="_E73E4HppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_E73E5XppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E73E6XppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_elZnBIBgEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_z5-_eR-3EeqCeNa5GcKdyg" target="_elZnAIBgEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_elZnBYBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_elZnCYBgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Signal" href="TapiStreaming.uml#_X9ay8LqKEemx9sMHf8Tuig"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_E73E5nppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E73E53ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E73E6HppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_elZnBoBgEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_elZnB4BgEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_elZnCIBgEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_E7_AtHppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_z6AOEB-3EeqCeNa5GcKdyg" target="_E7_AsHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_E7_AtXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E7_AuXppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_elnpcIBgEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_z6AOEB-3EeqCeNa5GcKdyg" target="_elnCYIBgEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_elnpcYBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_elnpdYBgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiStreaming.uml#_s9prgLqKEemx9sMHf8Tuig"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_E7_AtnppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E7_At3ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E7_AuHppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_elnpcoBgEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_elnpc4BgEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_elnpdIBgEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_E8O4VHppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_z5-_yR-3EeqCeNa5GcKdyg" target="_E8O4UHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_E8O4VXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E8O4WXppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_emArAIBgEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_z5-_yR-3EeqCeNa5GcKdyg" target="_emAD8IBgEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_emArAYBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_emArBYBgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_gv58QLqKEemx9sMHf8Tuig"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_E8O4VnppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E8O4V3ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E8O4WHppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_emArAoBgEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_emArA4BgEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_emArBIBgEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_E8bFlHppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_z6AOJB-3EeqCeNa5GcKdyg" target="_E8bFkHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_E8bFlXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E8bFmXppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_emU0FIBgEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_z6AOJB-3EeqCeNa5GcKdyg" target="_emU0EIBgEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_emU0FYBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_emU0GYBgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiStreaming.uml#_5n-CALqKEemx9sMHf8Tuig"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_E8bFlnppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E8bFl3ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E8bFmHppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_emU0FoBgEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_emU0F4BgEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_emU0GIBgEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_E8f-EHppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_z6AOSR-3EeqCeNa5GcKdyg" target="_E8fXAHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_E8f-EXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E8f-FXppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_ema6tIBgEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_z6AOSR-3EeqCeNa5GcKdyg" target="_ema6sIBgEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ema6tYBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_embhwoBgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiStreaming.uml#_AiVEsLqOEemx9sMHf8Tuig"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_E8f-EnppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E8f-E3ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E8f-FHppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ema6toBgEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_embhwIBgEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_embhwYBgEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_E8ldoXppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_z6AObh-3EeqCeNa5GcKdyg" target="_E8k2kHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_E8ldonppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E8ldpnppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_eml51IBgEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_z6AObh-3EeqCeNa5GcKdyg" target="_eml50IBgEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_eml51YBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_emmg4YBgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiStreaming.uml#__-BWYLqQEemx9sMHf8Tuig"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_E8ldo3ppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E8ldpHppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E8ldpXppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_eml51oBgEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eml514BgEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_emmg4IBgEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_E9CwoHppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_z5_AXh-3EeqCeNa5GcKdyg" target="_E9CJkHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_E9CwoXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E9CwpXppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_enc1dIBgEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_z5_AXh-3EeqCeNa5GcKdyg" target="_enc1cIBgEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_enc1dYBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_endcgIBgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiCommon.uml#_sfccMOK0EeSq5fATALSQkQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_E9CwonppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E9Cwo3ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E9CwpHppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_enc1doBgEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_enc1d4BgEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_enc1eIBgEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_E9byMXppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_z5_AtR-3EeqCeNa5GcKdyg" target="_E9bLIHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_E9byMnppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E9byNnppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_eoIx9IBgEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_z5_AtR-3EeqCeNa5GcKdyg" target="_eoIx8IBgEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_eoIx9YBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_eoIx-YBgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_6bbCwLqLEemx9sMHf8Tuig"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_E9byM3ppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E9byNHppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E9byNXppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_eoIx9oBgEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eoIx94BgEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eoIx-IBgEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_E9yXh3ppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_z5_kbx-3EeqCeNa5GcKdyg" target="_E9yXg3ppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_E9yXiHppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E9yXjHppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_eo_tkYBgEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_z5_kbx-3EeqCeNa5GcKdyg" target="_eo_GgIBgEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_eo_tkoBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_eo_tloBgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Interface" href="TapiStreaming.uml#_dBX4MLqOEemx9sMHf8Tuig"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_E9yXiXppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E9yXinppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E9yXi3ppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_eo_tk4BgEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eo_tlIBgEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eo_tlYBgEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_E-CPJHppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_z5_kvh-3EeqCeNa5GcKdyg" target="_E-CPIHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_E-CPJXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E-CPKXppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_epbLZIBgEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_z5_kvh-3EeqCeNa5GcKdyg" target="_epbLYIBgEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_epbLZYBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_epbLaYBgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_qFJloLqQEemx9sMHf8Tuig"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_E-CPJnppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E-CPJ3ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E-CPKHppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_epbLZoBgEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_epbLZ4BgEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_epbLaIBgEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_E--DRHppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_z5_nXR-3EeqCeNa5GcKdyg" target="_E--DQHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_E--DRXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E--DSXppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_erExMIBgEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_z5_nXR-3EeqCeNa5GcKdyg" target="_erEKIIBgEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_erExMYBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_erExNYBgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_MJPYYBXeEeqAktXlUG_iEw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_E--DRnppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E--DR3ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E--DSHppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_erExMoBgEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_erExM4BgEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_erExNIBgEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_E_LepHppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_z6AOyx-3EeqCeNa5GcKdyg" target="_E_LeoHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_E_LepXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E_LeqXppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_erg2FIBgEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_z6AOyx-3EeqCeNa5GcKdyg" target="_erg2EIBgEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_erg2FYBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_erg2GYBgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiStreaming.uml#_5Xt9oBXeEeqAktXlUG_iEw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_E_LepnppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E_Lep3ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E_LeqHppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_erg2FoBgEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_erg2F4BgEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_erg2GIBgEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_E_aIJHppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_z6AMFB-3EeqCeNa5GcKdyg" target="_E_aIIHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_E_aIJXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E_aIKXppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_er-wJIBgEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_z6AMFB-3EeqCeNa5GcKdyg" target="_er-wIIBgEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_er-wJYBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_er_XMoBgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Interface" href="TapiStreaming.uml#_S1CbEBy6EeqCeNa5GcKdyg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_E_aIJnppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E_aIJ3ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E_aIKHppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_er-wJoBgEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_er_XMIBgEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_er_XMYBgEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_E_scBHppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_woVFcB-_EeqCeNa5GcKdyg" target="_E_scAHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_E_scBXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E_scCXppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_eso3dIBgEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_woVFcB-_EeqCeNa5GcKdyg" target="_eso3cIBgEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_eso3dYBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_espegIBgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_jdeiEBy8EeqCeNa5GcKdyg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_E_scBnppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E_scB3ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E_scCHppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_eso3doBgEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eso3d4BgEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_eso3eIBgEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_E_3bJHppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_wsbiUB-_EeqCeNa5GcKdyg" target="_E_3bIHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_E_3bJXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E_3bKXppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_etGKdIBgEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_wsbiUB-_EeqCeNa5GcKdyg" target="_etGKcIBgEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_etGKdYBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_etGKeYBgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiStreaming.uml#_01YpEBy8EeqCeNa5GcKdyg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_E_3bJnppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E_3bJ3ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E_3bKHppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_etGKdoBgEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_etGKd4BgEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_etGKeIBgEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_E_8ToXppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_wvgrgB-_EeqCeNa5GcKdyg" target="_E_7skHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_E_8TonppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_E_8TpnppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_etQihIBgEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_wvgrgB-_EeqCeNa5GcKdyg" target="_etQigIBgEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_etQihYBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_etRJkoBgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Association" href="TapiStreaming.uml#_a-lNsBy9EeqCeNa5GcKdyg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_E_8To3ppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E_8TpHppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_E_8TpXppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_etQihoBgEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_etRJkIBgEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_etRJkYBgEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_FALkNHppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_wqlIMB-_EeqCeNa5GcKdyg" target="_FALkMHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_FALkNXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FALkOXppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_et0jNIBgEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_wqlIMB-_EeqCeNa5GcKdyg" target="_et0jMIBgEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_et0jNYBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_et0jOYBgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_R-mlEBXlEeqAktXlUG_iEw"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FALkNnppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FALkN3ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FALkOHppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_et0jNoBgEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_et0jN4BgEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_et0jOIBgEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_FAxaEXppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_K04yYy45EeqsBLPUmmYf3g" target="_FAwzAHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_FAxaEnppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FAxaFnppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_evEgZIBgEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_K04yYy45EeqsBLPUmmYf3g" target="_evEgYIBgEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_evEgZYBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_evFHcoBgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_B0Zw4B-1EeqCeNa5GcKdyg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FAxaE3ppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FAxaFHppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FAxaFXppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_evEgZoBgEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_evFHcIBgEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_evFHcYBgEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_FA9nVHppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_K06Agy45EeqsBLPUmmYf3g" target="_FA9nUHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_FA9nVXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FA9nWXppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_evdh9IBgEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_K06Agy45EeqsBLPUmmYf3g" target="_evdh8IBgEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_evdh9YBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_eveJAIBgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiStreaming.uml#_sBHOQB-1EeqCeNa5GcKdyg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FA9nVnppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FA9nV3ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FA9nWHppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_evdh9oBgEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_evdh94BgEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_evdh-IBgEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_FBM35HppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_K06Aly45EeqsBLPUmmYf3g" target="_FBM34HppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_FBM35XppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FBM36XppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_ewD-5IBgEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_K06Aly45EeqsBLPUmmYf3g" target="_ewD-4IBgEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ewD-5YBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ewD-6YBgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_4ZR50G31EemRDKXaAompzQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FBM35nppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FBM353ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FBM36HppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ewD-5oBgEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ewD-54BgEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ewD-6IBgEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_FBnHlHppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_yXeL0C45EeqsBLPUmmYf3g" target="_FBnHkHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_FBnHlXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FBnHmXppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_ewv7YYBgEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_yXeL0C45EeqsBLPUmmYf3g" target="_ewvUUIBgEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_ewv7YoBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_ewv7ZoBgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiStreaming.uml#_yXZTUC45EeqsBLPUmmYf3g"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FBnHlnppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FBnHl3ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FBnHmHppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_ewv7Y4BgEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ewv7ZIBgEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_ewv7ZYBgEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_FCDzhHppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_3UtCkD0mEeqNzoiCK4mkvg" target="_FCDzgHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_FCDzhXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FCDziXppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_exeUIYBgEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_3UtCkD0mEeqNzoiCK4mkvg" target="_exdtEIBgEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_exeUIoBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_exeUJoBgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Class" href="TapiStreaming.uml#_3Uj4oD0mEeqNzoiCK4mkvg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FCDzhnppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FCDzh3ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FCDziHppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_exeUI4BgEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_exeUJIBgEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_exeUJYBgEeqCy67P6xy4tg"/>
     </edges>
-    <edges xmi:type="notation:Connector" xmi:id="_FCOypHppEeqMpJXtwtppeQ" type="StereotypeCommentLink" source="_wYXGED0nEeqNzoiCK4mkvg" target="_FCOyoHppEeqMpJXtwtppeQ">
-      <styles xmi:type="notation:FontStyle" xmi:id="_FCOypXppEeqMpJXtwtppeQ"/>
-      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_FCOyqXppEeqMpJXtwtppeQ" name="BASE_ELEMENT">
+    <edges xmi:type="notation:Connector" xmi:id="_exxPFIBgEeqCy67P6xy4tg" type="StereotypeCommentLink" source="_wYXGED0nEeqNzoiCK4mkvg" target="_exxPEIBgEeqCy67P6xy4tg">
+      <styles xmi:type="notation:FontStyle" xmi:id="_exxPFYBgEeqCy67P6xy4tg"/>
+      <styles xmi:type="notation:EObjectValueStyle" xmi:id="_exxPGYBgEeqCy67P6xy4tg" name="BASE_ELEMENT">
         <eObjectValue xmi:type="uml:Abstraction" href="TapiStreaming.uml#_wYS0oD0nEeqNzoiCK4mkvg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_FCOypnppEeqMpJXtwtppeQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FCOyp3ppEeqMpJXtwtppeQ"/>
-      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_FCOyqHppEeqMpJXtwtppeQ"/>
+      <bendpoints xmi:type="notation:RelativeBendpoints" xmi:id="_exxPFoBgEeqCy67P6xy4tg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xmi:type="notation:IdentityAnchor" xmi:id="_exxPF4BgEeqCy67P6xy4tg"/>
+      <targetAnchor xmi:type="notation:IdentityAnchor" xmi:id="_exxPGIBgEeqCy67P6xy4tg"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_O8hXUEHbEeqO_YO5cZovrw" type="PapyrusUMLClassDiagram" name="StreamSkeleton" measurementUnit="Pixel">

--- a/UML/TapiStreaming.uml
+++ b/UML/TapiStreaming.uml
@@ -999,12 +999,6 @@ The list may be a subset of the classes within the context.</body>
             <body>Indicates the type of content of each log record.</body>
           </ownedComment>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_O6m-YDltEeqNzoiCK4mkvg" name="streamTypeId" isReadOnly="true">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_5EZcQDwuEeqNzoiCK4mkvg" annotatedElement="_O6m-YDltEeqNzoiCK4mkvg">
-            <body>The identifier for the stream type.</body>
-          </ownedComment>
-          <type xmi:type="uml:DataType" href="TapiCommon.uml#_FRi-QNnWEeWIOYiRCk5bbQ"/>
-        </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_eXlBcGWwEemRDKXaAompzQ" name="LogRecord">
         <ownedComment xmi:type="uml:Comment" xmi:id="_At2rQEGxEeqO_YO5cZovrw" annotatedElement="_eXlBcGWwEemRDKXaAompzQ">
@@ -1357,7 +1351,7 @@ Can be used to understand which elements of the record will be present.</body>
   </OpenModel_Profile:Specify>
   <OpenModel_Profile:OpenModelClass xmi:id="_6bbCwbqLEemx9sMHf8Tuig" base_Class="_6bbCwLqLEemx9sMHf8Tuig"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_6bbp0LqLEemx9sMHf8Tuig" base_Class="_6bbCwLqLEemx9sMHf8Tuig"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_7pwMMLqNEemx9sMHf8Tuig" base_StructuralFeature="_7pvlILqNEemx9sMHf8Tuig" partOfObjectKey="1"/>
+  <OpenModel_Profile:OpenModelAttribute xmi:id="_7pwMMLqNEemx9sMHf8Tuig" base_StructuralFeature="_7pvlILqNEemx9sMHf8Tuig"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_7pwMMbqNEemx9sMHf8Tuig" base_Property="_7pvlILqNEemx9sMHf8Tuig" writeAllowed="WRITE_NOT_ALLOWED"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_AiWS07qOEemx9sMHf8Tuig" base_StructuralFeature="_AiWS0rqOEemx9sMHf8Tuig"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_AiW54LqOEemx9sMHf8Tuig" base_Property="_AiWS0rqOEemx9sMHf8Tuig" writeAllowed="WRITE_NOT_ALLOWED"/>
@@ -1472,8 +1466,6 @@ Can be used to understand which elements of the record will be present.</body>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_SEwdcDkxEeqNzoiCK4mkvg" base_Property="_SEuoQDkxEeqNzoiCK4mkvg" writeAllowed="WRITE_NOT_ALLOWED"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_1h9tMDlCEeqNzoiCK4mkvg" base_StructuralFeature="_1h74ADlCEeqNzoiCK4mkvg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_1h-7UDlCEeqNzoiCK4mkvg" base_Property="_1h74ADlCEeqNzoiCK4mkvg"/>
-  <OpenModel_Profile:OpenModelAttribute xmi:id="_O6m-YTltEeqNzoiCK4mkvg" base_StructuralFeature="_O6m-YDltEeqNzoiCK4mkvg" partOfObjectKey="1" isInvariant="true"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_O6m-YjltEeqNzoiCK4mkvg" base_Property="_O6m-YDltEeqNzoiCK4mkvg" writeAllowed="WRITE_NOT_ALLOWED"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_2n5vcDuQEeqNzoiCK4mkvg" base_StructuralFeature="_2n5IYDuQEeqNzoiCK4mkvg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_2n6WgDuQEeqNzoiCK4mkvg" base_Property="_2n5IYDuQEeqNzoiCK4mkvg"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_V9pk4TxCEeqNzoiCK4mkvg" base_StructuralFeature="_V9pk4DxCEeqNzoiCK4mkvg" isInvariant="true"/>

--- a/UML/TapiStreaming.uml
+++ b/UML/TapiStreaming.uml
@@ -49,7 +49,7 @@ Hence a CLEAR will also cause a Tombstone record in a Compacted Log solution.</b
         <ownedComment xmi:type="uml:Comment" xmi:id="_gql3oDxhEeqNzoiCK4mkvg" annotatedElement="_Fe520G33EemRDKXaAompzQ">
           <body>At this point in the evolution of control solutions LegacyProperties are probably mandatory, however, it is anticipated that as control solutions advance the LegacyProperties will become irrelevant.</body>
         </ownedComment>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_ObQt0G33EemRDKXaAompzQ" name="perceivedSeverity" type="_5ByU4NwzEeaaobmDldrjOQ">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_ObQt0G33EemRDKXaAompzQ" name="perceivedSeverity" type="_iIJ3sIBCEeqCy67P6xy4tg">
           <ownedComment xmi:type="uml:Comment" xmi:id="_NhitsDxiEeqNzoiCK4mkvg" annotatedElement="_ObQt0G33EemRDKXaAompzQ">
             <body>A device will provide an indication of importance for each alarm. &#xD;
 This property indicates the importance.&#xD;
@@ -58,7 +58,7 @@ In some cases the severity may change through the life of an active alarm.</body
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_ZgeHsG33EemRDKXaAompzQ"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_ZgtYQG33EemRDKXaAompzQ" value="1"/>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_f3G5oG33EemRDKXaAompzQ" name="serviceAffecting" type="_5QUAwOcCEeaDNtnUN91VDg">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_f3G5oG33EemRDKXaAompzQ" name="serviceAffect" type="_stEA4IBCEeqCy67P6xy4tg">
           <ownedComment xmi:type="uml:Comment" xmi:id="_dT4lEDxiEeqNzoiCK4mkvg" annotatedElement="_f3G5oG33EemRDKXaAompzQ">
             <body>Some devices will indicate, from its very narrow viewpoint, whether service has been impacted or not.&#xD;
 This property carries this detail.</body>
@@ -85,57 +85,6 @@ This property can be used to convey this.</body>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_pN7BIDuREeqNzoiCK4mkvg"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_pPkm8DuREeqNzoiCK4mkvg" value="*"/>
         </ownedAttribute>
-      </packagedElement>
-      <packagedElement xmi:type="uml:Enumeration" xmi:id="_5ByU4NwzEeaaobmDldrjOQ" name="PerceivedSeverityType" isLeaf="true">
-        <ownedComment xmi:type="uml:Comment" xmi:id="_p009IDxiEeqNzoiCK4mkvg" annotatedElement="_5ByU4NwzEeaaobmDldrjOQ">
-          <body>The values for importance of an ACTIVE, INTERMITTENT or CLEAR alarm.</body>
-        </ownedComment>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_-WiMANwzEeaaobmDldrjOQ" name="CRITICAL">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_5H6FoDxiEeqNzoiCK4mkvg" annotatedElement="_-WiMANwzEeaaobmDldrjOQ">
-            <body>The higherst severity of ACTIVE/INTERMITTENT alarm.</body>
-          </ownedComment>
-        </ownedLiteral>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_9MhP8NwzEeaaobmDldrjOQ" name="MAJOR">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_7l1goDxiEeqNzoiCK4mkvg" annotatedElement="_9MhP8NwzEeaaobmDldrjOQ">
-            <body>The middle severity of ACTIVE/INTERMITTENT alarm.</body>
-          </ownedComment>
-        </ownedLiteral>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="__wAgYNwzEeaaobmDldrjOQ" name="MINOR">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_95bT4DxiEeqNzoiCK4mkvg" annotatedElement="__wAgYNwzEeaaobmDldrjOQ">
-            <body>The lowest severity of ACTIVE/INTERMITTENT alarm.</body>
-          </ownedComment>
-        </ownedLiteral>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_At-kgNw0EeaaobmDldrjOQ" name="WARNING">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_HkDmIDxjEeqNzoiCK4mkvg" annotatedElement="_At-kgNw0EeaaobmDldrjOQ">
-            <body>An extremely low importance ACTIVE/INTERMITTENT alarm (lowere than MINOR).</body>
-          </ownedComment>
-        </ownedLiteral>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_C8cnMNw0EeaaobmDldrjOQ" name="CLEARED">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_0jdqEDxiEeqNzoiCK4mkvg" annotatedElement="_C8cnMNw0EeaaobmDldrjOQ">
-            <body>The severity of a CLEAR where no other severity information is available.</body>
-          </ownedComment>
-        </ownedLiteral>
-      </packagedElement>
-      <packagedElement xmi:type="uml:Enumeration" xmi:id="_5QUAwOcCEeaDNtnUN91VDg" name="ServiceAffecting" isLeaf="true">
-        <ownedComment xmi:type="uml:Comment" xmi:id="_OLOucDxjEeqNzoiCK4mkvg" annotatedElement="_5QUAwOcCEeaDNtnUN91VDg">
-          <body>Indicates whether the device considers the condition to be impacting service.&#xD;
-Note that the detected condition along with knowledge of the topology and protection provide a more suitable approach.</body>
-        </ownedComment>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_D2NBYOcDEeaDNtnUN91VDg" name="SERVICE_AFFECTING">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_VHyQ4DxjEeqNzoiCK4mkvg" annotatedElement="_D2NBYOcDEeaDNtnUN91VDg">
-            <body>The condition is believed to impact service.</body>
-          </ownedComment>
-        </ownedLiteral>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_FvNKYOcDEeaDNtnUN91VDg" name="NOT_SERVICE_AFFECTING">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_SObeIDxjEeqNzoiCK4mkvg" annotatedElement="_FvNKYOcDEeaDNtnUN91VDg">
-            <body>The condition is believed to not impact service.</body>
-          </ownedComment>
-        </ownedLiteral>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_HCD5YOcDEeaDNtnUN91VDg" name="UNKNOWN">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_YjW_4DxjEeqNzoiCK4mkvg" annotatedElement="_HCD5YOcDEeaDNtnUN91VDg">
-            <body>The service impact of the condition is not known.</body>
-          </ownedComment>
-        </ownedLiteral>
       </packagedElement>
       <packagedElement xmi:type="uml:Enumeration" xmi:id="_-5CrYMEfEemNuM6W9x-XhQ" name="LogRecordStrategy">
         <ownedComment xmi:type="uml:Comment" xmi:id="_FxOBAEG9EeqO_YO5cZovrw" annotatedElement="_-5CrYMEfEemNuM6W9x-XhQ">
@@ -575,29 +524,6 @@ Is only a LogRecordHeader with no LogRecordBody.</body>
           </ownedComment>
         </ownedLiteral>
       </packagedElement>
-      <packagedElement xmi:type="uml:Enumeration" xmi:id="_bgwjsCzeEeaYO8M_h7XJ5A" name="EventSourceIndicator" isLeaf="true">
-        <ownedComment xmi:type="uml:Comment" xmi:id="_lpdysEHCEeqO_YO5cZovrw" annotatedElement="_bgwjsCzeEeaYO8M_h7XJ5A">
-          <body>Source of the event.&#xD;
-Use to give some idea of the time characteristics of the event source.</body>
-        </ownedComment>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_ggplICzeEeaYO8M_h7XJ5A" name="RESOURCE_OPERATION">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_3wzykEHCEeqO_YO5cZovrw" annotatedElement="_ggplICzeEeaYO8M_h7XJ5A">
-            <body>The event is from the operation of the network resources.&#xD;
-The event source has a relatively fast time characteristic.</body>
-          </ownedComment>
-        </ownedLiteral>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_h_dFcCzeEeaYO8M_h7XJ5A" name="MANAGEMENT_OPERATION">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_wn0WoEHCEeqO_YO5cZovrw" annotatedElement="_h_dFcCzeEeaYO8M_h7XJ5A">
-            <body>Event is from a Management operation (slow control).&#xD;
-The event source has a relatively slow time characteristic.</body>
-          </ownedComment>
-        </ownedLiteral>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_jrUKUCzeEeaYO8M_h7XJ5A" name="UNKNOWN">
-          <ownedComment xmi:type="uml:Comment" xmi:id="_-H7FoEHCEeqO_YO5cZovrw" annotatedElement="_jrUKUCzeEeaYO8M_h7XJ5A">
-            <body>The origin of the event is not known.</body>
-          </ownedComment>
-        </ownedLiteral>
-      </packagedElement>
       <packagedElement xmi:type="uml:Enumeration" xmi:id="_IMaaMO9BEemCAts4PegeWw" name="SourcePrecision">
         <ownedComment xmi:type="uml:Comment" xmi:id="_VrKGcEHDEeqO_YO5cZovrw" annotatedElement="_IMaaMO9BEemCAts4PegeWw">
           <body>Alternative statements about timing precision at the event source.</body>
@@ -659,6 +585,80 @@ This drives the conditional augment.</body>
 The underlying raw detector is two state from the perspective of the monitored condition. &#xD;
 The detector is asymmetric in nature. &#xD;
 One state indicates that there is a problem and the other state indicates that there is no problem.</body>
+          </ownedComment>
+        </ownedLiteral>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_yxpO8IBBEeqCy67P6xy4tg" name="EventSource" isLeaf="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_yxpO8YBBEeqCy67P6xy4tg" annotatedElement="_yxpO8IBBEeqCy67P6xy4tg">
+          <body>Source of the event.&#xD;
+Use to give some idea of the time characteristics of the event source.</body>
+        </ownedComment>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_yxpO8oBBEeqCy67P6xy4tg" name="RESOURCE_OPERATION">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_yxpO84BBEeqCy67P6xy4tg" annotatedElement="_yxpO8oBBEeqCy67P6xy4tg">
+            <body>The event is from the operation of the network resources.&#xD;
+The event source has a relatively fast time characteristic.</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_yxpO9IBBEeqCy67P6xy4tg" name="MANAGEMENT_OPERATION">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_yxpO9YBBEeqCy67P6xy4tg" annotatedElement="_yxpO9IBBEeqCy67P6xy4tg">
+            <body>Event is from a Management operation (slow control).&#xD;
+The event source has a relatively slow time characteristic.</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_yxpO9oBBEeqCy67P6xy4tg" name="UNKNOWN">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_yxpO94BBEeqCy67P6xy4tg" annotatedElement="_yxpO9oBBEeqCy67P6xy4tg">
+            <body>The origin of the event is not known.</body>
+          </ownedComment>
+        </ownedLiteral>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_iIJ3sIBCEeqCy67P6xy4tg" name="PerceivedSeverity" isLeaf="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_iIJ3sYBCEeqCy67P6xy4tg" annotatedElement="_iIJ3sIBCEeqCy67P6xy4tg">
+          <body>The values for importance of an ACTIVE, INTERMITTENT or CLEAR alarm.</body>
+        </ownedComment>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_iIJ3soBCEeqCy67P6xy4tg" name="CRITICAL">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_iIJ3s4BCEeqCy67P6xy4tg" annotatedElement="_iIJ3soBCEeqCy67P6xy4tg">
+            <body>The higherst severity of ACTIVE/INTERMITTENT alarm.</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_iIJ3tIBCEeqCy67P6xy4tg" name="MAJOR">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_iIJ3tYBCEeqCy67P6xy4tg" annotatedElement="_iIJ3tIBCEeqCy67P6xy4tg">
+            <body>The middle severity of ACTIVE/INTERMITTENT alarm.</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_iIJ3toBCEeqCy67P6xy4tg" name="MINOR">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_iIJ3t4BCEeqCy67P6xy4tg" annotatedElement="_iIJ3toBCEeqCy67P6xy4tg">
+            <body>The lowest severity of ACTIVE/INTERMITTENT alarm.</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_iIJ3uIBCEeqCy67P6xy4tg" name="WARNING">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_iIJ3uYBCEeqCy67P6xy4tg" annotatedElement="_iIJ3uIBCEeqCy67P6xy4tg">
+            <body>An extremely low importance ACTIVE/INTERMITTENT alarm (lowere than MINOR).</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_iIJ3uoBCEeqCy67P6xy4tg" name="CLEARED">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_iIJ3u4BCEeqCy67P6xy4tg" annotatedElement="_iIJ3uoBCEeqCy67P6xy4tg">
+            <body>The severity of a CLEAR where no other severity information is available.</body>
+          </ownedComment>
+        </ownedLiteral>
+      </packagedElement>
+      <packagedElement xmi:type="uml:Enumeration" xmi:id="_stEA4IBCEeqCy67P6xy4tg" name="ServiceAffect" isLeaf="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_stEA4YBCEeqCy67P6xy4tg" annotatedElement="_stEA4IBCEeqCy67P6xy4tg">
+          <body>Indicates whether the device considers the condition to be impacting service.&#xD;
+Note that the detected condition along with knowledge of the topology and protection provide a more suitable approach.</body>
+        </ownedComment>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_stEA4oBCEeqCy67P6xy4tg" name="SERVICE_AFFECTING">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_stEA44BCEeqCy67P6xy4tg" annotatedElement="_stEA4oBCEeqCy67P6xy4tg">
+            <body>The condition is believed to impact service.</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_stEA5IBCEeqCy67P6xy4tg" name="NOT_SERVICE_AFFECTING">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_stEA5YBCEeqCy67P6xy4tg" annotatedElement="_stEA5IBCEeqCy67P6xy4tg">
+            <body>The condition is believed to not impact service.</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_stEA5oBCEeqCy67P6xy4tg" name="UNKNOWN">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_stEA54BCEeqCy67P6xy4tg" annotatedElement="_stEA5oBCEeqCy67P6xy4tg">
+            <body>The service impact of the condition is not known.</body>
           </ownedComment>
         </ownedLiteral>
       </packagedElement>
@@ -1035,7 +1035,7 @@ The list may be a subset of the classes within the context.</body>
 The structure allows for time uncertainty.</body>
           </ownedComment>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_Ik40YGW0EemRDKXaAompzQ" name="eventSourceIndicator" type="_bgwjsCzeEeaYO8M_h7XJ5A" isReadOnly="true">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_Ik40YGW0EemRDKXaAompzQ" name="eventSource" type="_yxpO8IBBEeqCy67P6xy4tg" isReadOnly="true">
           <ownedComment xmi:type="uml:Comment" xmi:id="_cnPIYGW0EemRDKXaAompzQ" annotatedElement="_Ik40YGW0EemRDKXaAompzQ">
             <body>Indicates whether the source is controlled (under management control) or potentially chaotic (under resource control).&#xD;
 The time characteristic of the source may be determined from the metadata describing the resource (e.g., a detector).&#xD;
@@ -1043,7 +1043,7 @@ Where there is an alternative (and probably more detailed) source of information
           </ownedComment>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_YzctsGW0EemRDKXaAompzQ"/>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_Yzl3oGW0EemRDKXaAompzQ" value="1"/>
-          <defaultValue xmi:type="uml:InstanceValue" xmi:id="_yNveEPtiEemCAts4PegeWw" type="_bgwjsCzeEeaYO8M_h7XJ5A" instance="_jrUKUCzeEeaYO8M_h7XJ5A"/>
+          <defaultValue xmi:type="uml:InstanceValue" xmi:id="_yNveEPtiEemCAts4PegeWw" type="_yxpO8IBBEeqCy67P6xy4tg" instance="_yxpO9oBBEeqCy67P6xy4tg"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_EyPzwGW1EemRDKXaAompzQ" name="additionalEventInfo" isReadOnly="true">
           <ownedComment xmi:type="uml:Comment" xmi:id="_TsflgGW1EemRDKXaAompzQ" annotatedElement="_EyPzwGW1EemRDKXaAompzQ">

--- a/UML/TapiStreaming.uml
+++ b/UML/TapiStreaming.uml
@@ -432,6 +432,11 @@ Local class. For streaming this requires parentAddress (when reporting the entit
 Local class. For streaming this requires parentAddress (when reporting the entity alone) or a combination of measuredEntityUuid and measuredEntityLocalId when reporting conditions.</body>
           </ownedComment>
         </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_LIBL0IBhEeqCy67P6xy4tg" name="ANY_CLASS">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_Sk7pUIBhEeqCy67P6xy4tg" annotatedElement="_LIBL0IBhEeqCy67P6xy4tg">
+            <body>Empty structure.</body>
+          </ownedComment>
+        </ownedLiteral>
       </packagedElement>
       <packagedElement xmi:type="uml:Enumeration" xmi:id="_DdDxwPsLEemCAts4PegeWw" name="StreamState">
         <ownedComment xmi:type="uml:Comment" xmi:id="_0eKEIEHEEeqO_YO5cZovrw" annotatedElement="_DdDxwPsLEemCAts4PegeWw">
@@ -585,6 +590,11 @@ This drives the conditional augment.</body>
 The underlying raw detector is two state from the perspective of the monitored condition. &#xD;
 The detector is asymmetric in nature. &#xD;
 One state indicates that there is a problem and the other state indicates that there is no problem.</body>
+          </ownedComment>
+        </ownedLiteral>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_GPnH4IBgEeqCy67P6xy4tg" name="EVENT_DETECTOR">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_TSH78IBgEeqCy67P6xy4tg" annotatedElement="_GPnH4IBgEeqCy67P6xy4tg">
+            <body>A type of detector used for reporting events.</body>
           </ownedComment>
         </ownedLiteral>
       </packagedElement>

--- a/UML/TapiStreaming.uml
+++ b/UML/TapiStreaming.uml
@@ -913,7 +913,7 @@ The format of the address and attachment mechnism will depend on the connection 
             <body>The state of the stream.</body>
           </ownedComment>
         </ownedAttribute>
-        <ownedAttribute xmi:type="uml:Property" xmi:id="_PZCfwPsEEemCAts4PegeWw" name="_streamConnectionType" type="_qFJloLqQEemx9sMHf8Tuig" isReadOnly="true" association="_PY-1YPsEEemCAts4PegeWw">
+        <ownedAttribute xmi:type="uml:Property" xmi:id="_PZCfwPsEEemCAts4PegeWw" name="_supportedStreamType" type="_qFJloLqQEemx9sMHf8Tuig" isReadOnly="true" association="_PY-1YPsEEemCAts4PegeWw">
           <ownedComment xmi:type="uml:Comment" xmi:id="_EJmO0EGwEeqO_YO5cZovrw" annotatedElement="_PZCfwPsEEemCAts4PegeWw">
             <body>Identifies the type of stream that is available for connection.</body>
           </ownedComment>

--- a/UML/TapiStreaming.uml
+++ b/UML/TapiStreaming.uml
@@ -1452,7 +1452,7 @@ Can be used to understand which elements of the record will be present.</body>
   <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_B0Zw4R-1EeqCeNa5GcKdyg" base_Class="_B0Zw4B-1EeqCeNa5GcKdyg"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_B0aX8B-1EeqCeNa5GcKdyg" base_Class="_B0Zw4B-1EeqCeNa5GcKdyg"/>
   <OpenModel_Profile:Specify xmi:id="_0Hb1IB-1EeqCeNa5GcKdyg" base_Abstraction="_sBHOQB-1EeqCeNa5GcKdyg">
-    <target>/TapiStreaming:StreamRecord:_streamRecord/TapiStreaming:StreamRecord:_logRecord/TapiStreaming:LogRecord:_logRecordBody/TapiStreaming:LogRecordBody:_conditionDetectorRecord</target>
+    <target>/TapiStreaming:StreamRecord:_streamRecord/TapiStreaming:StreamRecord:_logRecord/TapiStreaming:LogRecord:_logRecordBody/TapiStreaming:LogRecordBody:_conditionDetector</target>
   </OpenModel_Profile:Specify>
   <OpenModel_Profile:Specify xmi:id="_92mhkC45EeqsBLPUmmYf3g" base_Abstraction="_yXZTUC45EeqsBLPUmmYf3g">
     <target>/TapiStreaming:StreamRecord:_streamRecord/TapiStreaming:StreamRecord:_logRecord/TapiStreaming:LogRecord:_logRecordBody</target>
@@ -1483,9 +1483,15 @@ Can be used to understand which elements of the record will be present.</body>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_Wx2kgXNiEeqfmpW3vMmyvQ" base_Property="_WxuosHNiEeqfmpW3vMmyvQ" writeAllowed="WRITE_NOT_ALLOWED"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_b2KrMHf9EeqhQsSsGiMOkA" base_Property="_b2JdEHf9EeqhQsSsGiMOkA" writeAllowed="WRITE_NOT_ALLOWED"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_b2MgYHf9EeqhQsSsGiMOkA" base_StructuralFeature="_b2JdEHf9EeqhQsSsGiMOkA" isInvariant="true"/>
-  <OpenModel_Profile:Specify xmi:id="_BH9y0Hl0EeqVN_GB3rPx7g" base_Abstraction="_7LB6UHlzEeqVN_GB3rPx7g"/>
-  <OpenModel_Profile:Specify xmi:id="_CjjnEHl0EeqVN_GB3rPx7g" base_Abstraction="_8WlugHlzEeqVN_GB3rPx7g"/>
-  <OpenModel_Profile:Specify xmi:id="_E4IRwHl0EeqVN_GB3rPx7g" base_Abstraction="_-KswcHlzEeqVN_GB3rPx7g"/>
+  <OpenModel_Profile:Specify xmi:id="_BH9y0Hl0EeqVN_GB3rPx7g" base_Abstraction="_7LB6UHlzEeqVN_GB3rPx7g">
+    <target>/TapiStreaming:StreamRecord:_streamRecord/TapiStreaming:StreamRecord:_logRecord/TapiStreaming:LogRecord:_logRecordBody</target>
+  </OpenModel_Profile:Specify>
+  <OpenModel_Profile:Specify xmi:id="_CjjnEHl0EeqVN_GB3rPx7g" base_Abstraction="_8WlugHlzEeqVN_GB3rPx7g">
+    <target>/TapiStreaming:StreamRecord:_streamRecord/TapiStreaming:StreamRecord:_logRecord/TapiStreaming:LogRecord:_logRecordBody</target>
+  </OpenModel_Profile:Specify>
+  <OpenModel_Profile:Specify xmi:id="_E4IRwHl0EeqVN_GB3rPx7g" base_Abstraction="_-KswcHlzEeqVN_GB3rPx7g">
+    <target>/TapiStreaming:StreamRecord:_streamRecord/TapiStreaming:StreamRecord:_logRecord/TapiStreaming:LogRecord:_logRecordBody</target>
+  </OpenModel_Profile:Specify>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_5PcBEH45EeqMpJXtwtppeQ" base_StructuralFeature="_5PbaAH45EeqMpJXtwtppeQ" isInvariant="true"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_5PcoIH45EeqMpJXtwtppeQ" base_Property="_5PbaAH45EeqMpJXtwtppeQ" writeAllowed="WRITE_NOT_ALLOWED"/>
 </xmi:XMI>


### PR DESCRIPTION
Method of construction of streaming caused three data types in streaming
to have the same xmi id in the .uml file as three data types in
notification. This caused the UML-Yang tooling to build a dependency
between streaming and notification when both were generated together.
This has now been fixed in Streaming. In the process the names of the
types have also been changed to make the visibly distinct in the Yang.
The literal names of the Enumerations have not been changed as these are
only locally relevant in the types.