### PR TITLE
Imporvements to layout of diagrams for gendoc generation

### DIFF
--- a/UML/TapiStreamingGnmi.notation
+++ b/UML/TapiStreamingGnmi.notation
@@ -34,7 +34,7 @@
         <element href="TapiStreamingGnmi.uml#_gcZyQN2TEeyisriSvKT5Lw"/>
       </children>
       <element href="TapiStreamingGnmi.uml#_gcZyQN2TEeyisriSvKT5Lw"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_kiEsJ7HDEe2tjo53LmkUFA" x="240" y="-760" width="141" height="21"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_kiEsJ7HDEe2tjo53LmkUFA" x="-180" y="-760" width="201" height="21"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_kiEsMLHDEe2tjo53LmkUFA" type="Comment_Shape" fontName="Segoe UI" fontHeight="6" fillColor="8905185">
       <eAnnotations xmi:id="_kiEsMbHDEe2tjo53LmkUFA" source="PapyrusCSSForceValue">
@@ -47,7 +47,7 @@
         <element href="TapiStreamingGnmi.uml#_a-WOIN2TEeyisriSvKT5Lw"/>
       </children>
       <element href="TapiStreamingGnmi.uml#_a-WOIN2TEeyisriSvKT5Lw"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_kiEsN7HDEe2tjo53LmkUFA" x="240" y="-640" width="141" height="21"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_kiEsN7HDEe2tjo53LmkUFA" x="-180" y="-640" width="201" height="21"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_kiEsOLHDEe2tjo53LmkUFA" type="Enumeration_Shape" fontName="Segoe UI" fontHeight="6" fillColor="8905185">
       <eAnnotations xmi:id="_hDT-4LHGEe2tjo53LmkUFA" source="PapyrusCSSForceValue">
@@ -142,7 +142,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="_kiEshLHDEe2tjo53LmkUFA"/>
       </children>
       <element href="TapiStreamingGnmi.uml#_nwJQkKYQEe2n-fmfRwdlPg"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_kiEsiLHDEe2tjo53LmkUFA" y="160" width="181" height="101"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_kiEsiLHDEe2tjo53LmkUFA" x="-180" y="160" width="241" height="121"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_kiGhULHDEe2tjo53LmkUFA" type="Enumeration_Shape" fontName="Segoe UI" fontHeight="6" fillColor="8905185">
       <eAnnotations xmi:id="_kiGhUbHDEe2tjo53LmkUFA" source="PapyrusCSSForceValue">
@@ -237,7 +237,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="_kiGhfrHDEe2tjo53LmkUFA"/>
       </children>
       <element href="TapiStreamingGnmi.uml#_7yFhkKbkEe2n-fmfRwdlPg"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_kiGhgrHDEe2tjo53LmkUFA" y="480" width="221" height="101"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_kiGhgrHDEe2tjo53LmkUFA" x="-180" y="480" width="301" height="121"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_kiHIZ7HDEe2tjo53LmkUFA" type="DataType_Shape" fontName="Segoe UI" fontHeight="6" fillColor="8905185">
       <eAnnotations xmi:id="_kiHIaLHDEe2tjo53LmkUFA" source="PapyrusCSSForceValue">
@@ -498,7 +498,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="_kiHJFLHDEe2tjo53LmkUFA"/>
       </children>
       <element href="TapiStreamingGnmi.uml#_tGy2YKJFEe2n-fmfRwdlPg"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_kiHJGLHDEe2tjo53LmkUFA" y="-40" width="341" height="141"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_kiHJGLHDEe2tjo53LmkUFA" x="-180" y="-40" width="341" height="141"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_kiHvfrHDEe2tjo53LmkUFA" type="Enumeration_Shape" fontName="Segoe UI" fontHeight="6" fillColor="8905185">
       <eAnnotations xmi:id="_kiHvf7HDEe2tjo53LmkUFA" source="PapyrusCSSForceValue">
@@ -593,7 +593,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="_kiHvzrHDEe2tjo53LmkUFA"/>
       </children>
       <element href="TapiStreamingGnmi.uml#_OSJcgKZuEe2n-fmfRwdlPg"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_kiHv0rHDEe2tjo53LmkUFA" y="320" width="181" height="101"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_kiHv0rHDEe2tjo53LmkUFA" x="-180" y="320" width="241" height="121"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_kiHv07HDEe2tjo53LmkUFA" type="Enumeration_Shape" fontName="Segoe UI" fontHeight="6" fillColor="8905185">
       <eAnnotations xmi:id="_kiHv1LHDEe2tjo53LmkUFA" source="PapyrusCSSForceValue">
@@ -742,7 +742,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="_kiIWnLHDEe2tjo53LmkUFA"/>
       </children>
       <element href="TapiStreamingGnmi.uml#_FbS6sKbpEe2n-fmfRwdlPg"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_kiIWoLHDEe2tjo53LmkUFA" y="640" width="321" height="161"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_kiIWoLHDEe2tjo53LmkUFA" x="-180" y="640" width="421" height="161"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_kiIWobHDEe2tjo53LmkUFA" type="Comment_Shape" fontName="Segoe UI" fontHeight="6" fillColor="12621752">
       <eAnnotations xmi:id="_kiIWorHDEe2tjo53LmkUFA" source="PapyrusCSSForceValue">
@@ -755,7 +755,7 @@
         <element href="TapiStreamingGnmi.uml#_CfYvcN2UEeyisriSvKT5Lw"/>
       </children>
       <element href="TapiStreamingGnmi.uml#_CfYvcN2UEeyisriSvKT5Lw"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_kiIWqLHDEe2tjo53LmkUFA" x="240" y="-680" width="141" height="21"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_kiIWqLHDEe2tjo53LmkUFA" x="-180" y="-680" width="201" height="21"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_kiIW4bHDEe2tjo53LmkUFA" type="Class_Shape" fontName="Segoe UI" fontHeight="6" fillColor="12621752">
       <eAnnotations xmi:id="_kiIW4rHDEe2tjo53LmkUFA" source="PapyrusCSSForceValue">
@@ -874,7 +874,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="_kiIW97HDEe2tjo53LmkUFA"/>
       </children>
       <element href="TapiStreamingGnmi.uml#_FCwpUKYBEe2n-fmfRwdlPg"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_kiIXIbHDEe2tjo53LmkUFA" x="960" y="320" width="301" height="61"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_kiIXIbHDEe2tjo53LmkUFA" x="1200" y="320" width="401" height="61"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_kiI9q7HDEe2tjo53LmkUFA" type="Class_Shape" fontName="Segoe UI" fontHeight="6" fillColor="10011046">
       <eAnnotations xmi:id="_kiI9rLHDEe2tjo53LmkUFA" source="PapyrusCSSForceValue">
@@ -981,7 +981,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="_kiI_frHDEe2tjo53LmkUFA"/>
       </children>
       <element href="TapiOam.uml#_vnyfgF0IEeipas1p-rFJBA"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_kiI_qLHDEe2tjo53LmkUFA" x="1020" y="400" width="241" height="181"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_kiI_qLHDEe2tjo53LmkUFA" x="1300" y="400" width="301" height="181"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_kiLZ0LHDEe2tjo53LmkUFA" type="Class_Shape" fontName="Segoe UI" fontHeight="6" fillColor="12621752">
       <eAnnotations xmi:id="_kiLZ0bHDEe2tjo53LmkUFA" source="PapyrusCSSForceValue">
@@ -1244,7 +1244,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="_kiLcyLHDEe2tjo53LmkUFA"/>
       </children>
       <element href="TapiStreamingGnmi.uml#_406Q8KFhEe2n-fmfRwdlPg"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_kiLc8rHDEe2tjo53LmkUFA" x="380" y="580" width="381" height="221"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_kiLc8rHDEe2tjo53LmkUFA" x="300" y="580" width="581" height="221"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_kiOdILHDEe2tjo53LmkUFA" type="Class_Shape" fontName="Segoe UI" fontHeight="6" fillColor="12621752">
       <eAnnotations xmi:id="_kiOdIbHDEe2tjo53LmkUFA" source="PapyrusCSSForceValue">
@@ -1319,7 +1319,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="_kiOdaLHDEe2tjo53LmkUFA"/>
       </children>
       <element href="TapiStreamingGnmi.uml#_Aow5sKFgEe2n-fmfRwdlPg"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_kiOdkrHDEe2tjo53LmkUFA" x="400" y="180" width="321" height="60"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_kiOdkrHDEe2tjo53LmkUFA" x="320" y="180" width="481" height="60"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_q9G14LHDEe2tjo53LmkUFA" type="Signal_Shape" fontName="Segoe UI" fontHeight="6" fillColor="8047085">
       <eAnnotations xmi:id="_eI41ILHGEe2tjo53LmkUFA" source="PapyrusCSSForceValue">
@@ -1338,7 +1338,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="_q9JSJLHDEe2tjo53LmkUFA"/>
       </children>
       <element href="TapiStreaming.uml#_X9ay8LqKEemx9sMHf8Tuig"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_q9G14bHDEe2tjo53LmkUFA" x="420" y="-760" width="281" height="61"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_q9G14bHDEe2tjo53LmkUFA" x="380" y="-760" width="361" height="61"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_QmBGALHGEe2tjo53LmkUFA" type="Comment_Shape" fontName="Segoe UI" fontHeight="6" fillColor="10011046">
       <eAnnotations xmi:id="_YPOTELHGEe2tjo53LmkUFA" source="PapyrusCSSForceValue">
@@ -1348,7 +1348,7 @@
       </eAnnotations>
       <children xsi:type="notation:DecorationNode" xmi:id="_QmBGArHGEe2tjo53LmkUFA" type="Comment_BodyLabel"/>
       <element href="TapiStreamingGnmi.uml#_Ql-pwLHGEe2tjo53LmkUFA"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_QmBGAbHGEe2tjo53LmkUFA" x="240" y="-560" width="141" height="21"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_QmBGAbHGEe2tjo53LmkUFA" x="-180" y="-560" width="201" height="21"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_7AfSkLHGEe2tjo53LmkUFA" type="Class_Shape" fontName="Segoe UI" fontHeight="6" fillColor="10011046">
       <eAnnotations xmi:id="_Ap05oLHHEe2tjo53LmkUFA" source="PapyrusCSSForceValue">
@@ -1424,7 +1424,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="_7Af5sLHGEe2tjo53LmkUFA"/>
       </children>
       <element href="TapiOam.uml#_-2fMYF0KEeipas1p-rFJBA"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_7AfSkbHGEe2tjo53LmkUFA" x="1020" y="600" width="241" height="121"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_7AfSkbHGEe2tjo53LmkUFA" x="1300" y="600" width="301" height="121"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_Z9c6ALHHEe2tjo53LmkUFA" type="Class_Shape" fontName="Segoe UI" fontHeight="6" fillColor="10011046">
       <eAnnotations xmi:id="_hCIdsLHHEe2tjo53LmkUFA" source="PapyrusCSSForceValue">
@@ -1473,7 +1473,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="_Z9dhILHHEe2tjo53LmkUFA"/>
       </children>
       <element href="TapiOam.uml#_RRNb8DU7Eem_pr37XaewKQ"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_Z9c6AbHHEe2tjo53LmkUFA" x="1020" y="740" width="221" height="61"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_Z9c6AbHHEe2tjo53LmkUFA" x="1300" y="740" width="281" height="61"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_yn1tgLv2Ee2tPvK7TLwO7Q" type="Class_Shape" fontName="Segoe UI" fontHeight="6" fillColor="13420443">
       <eAnnotations xmi:id="_qak7tLv3Ee2tPvK7TLwO7Q" source="PapyrusCSSForceValue">
@@ -1504,7 +1504,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="_yn3iwbv2Ee2tPvK7TLwO7Q"/>
       </children>
       <element href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_yn1tgbv2Ee2tPvK7TLwO7Q" x="820" y="640" width="162" height="40"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_yn1tgbv2Ee2tPvK7TLwO7Q" x="1080" y="640" width="162" height="40"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_266sQLv2Ee2tPvK7TLwO7Q" type="Class_Shape" fontName="Segoe UI" fontHeight="6" fillColor="10011046">
       <eAnnotations xmi:id="_qak7srv3Ee2tPvK7TLwO7Q" source="PapyrusCSSForceValue">
@@ -1535,7 +1535,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="_266sU7v2Ee2tPvK7TLwO7Q"/>
       </children>
       <element href="TapiOam.uml#_CE0kkLwmEeSpn78DYJKtkA"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_266sQbv2Ee2tPvK7TLwO7Q" x="820" y="760" width="161" height="41"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_266sQbv2Ee2tPvK7TLwO7Q" x="1080" y="760" width="161" height="41"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_5PZ3YLv2Ee2tPvK7TLwO7Q" type="Class_Shape" fontName="Segoe UI" fontHeight="6" fillColor="10011046">
       <eAnnotations xmi:id="_qak7sLv3Ee2tPvK7TLwO7Q" source="PapyrusCSSForceValue">
@@ -1566,7 +1566,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="_5Paeebv2Ee2tPvK7TLwO7Q"/>
       </children>
       <element href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_5PZ3Ybv2Ee2tPvK7TLwO7Q" x="820" y="700" width="161" height="40"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_5PZ3Ybv2Ee2tPvK7TLwO7Q" x="1080" y="700" width="161" height="40"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_U6dCILv3Ee2tPvK7TLwO7Q" type="Comment_Shape" fontName="Segoe UI" fontHeight="6" fillColor="13420443">
       <eAnnotations xmi:id="_ecqYMLv3Ee2tPvK7TLwO7Q" source="PapyrusCSSForceValue">
@@ -1576,7 +1576,7 @@
       </eAnnotations>
       <children xsi:type="notation:DecorationNode" xmi:id="_U6dCIrv3Ee2tPvK7TLwO7Q" type="Comment_BodyLabel"/>
       <element href="TapiStreamingGnmi.uml#_U6ZXwLv3Ee2tPvK7TLwO7Q"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_U6dCIbv3Ee2tPvK7TLwO7Q" x="240" y="-600" width="141" height="21"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_U6dCIbv3Ee2tPvK7TLwO7Q" x="-180" y="-600" width="201" height="21"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_Uje8cLzPEe2tPvK7TLwO7Q" type="Class_Shape" fontName="Segoe UI" fontHeight="6" fillColor="12560536">
       <eAnnotations xmi:id="_Blj1sLzWEe2tPvK7TLwO7Q" source="PapyrusCSSForceValue">
@@ -1645,7 +1645,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="_UjgxrrzPEe2tPvK7TLwO7Q"/>
       </children>
       <element href="TapiStreamingGnmi.uml#_UjNPoLzPEe2tPvK7TLwO7Q"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_Uje8cbzPEe2tPvK7TLwO7Q" x="420" y="-640" width="281" height="61"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_Uje8cbzPEe2tPvK7TLwO7Q" x="380" y="-640" width="361" height="61"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_jAwzcLzREe2tPvK7TLwO7Q" type="Class_Shape" fontName="Segoe UI" fontHeight="6" fillColor="12560536">
       <eAnnotations xmi:id="_Blj1srzWEe2tPvK7TLwO7Q" source="PapyrusCSSForceValue">
@@ -1790,7 +1790,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="_jAxairzREe2tPvK7TLwO7Q"/>
       </children>
       <element href="TapiStreamingGnmi.uml#_jAoQkLzREe2tPvK7TLwO7Q"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_jAwzcbzREe2tPvK7TLwO7Q" x="420" y="-520" width="281" height="121"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_jAwzcbzREe2tPvK7TLwO7Q" x="380" y="-520" width="361" height="121"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_LyWcALzlEe2tPvK7TLwO7Q" type="Class_Shape" fontName="Segoe UI" fontHeight="6" fillColor="12560536">
       <eAnnotations xmi:id="_zy3HkLzlEe2tPvK7TLwO7Q" source="PapyrusCSSForceValue">
@@ -1821,7 +1821,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="_LyWcE7zlEe2tPvK7TLwO7Q"/>
       </children>
       <element href="TapiStreamingGnmi.uml#_LyQ8cLzlEe2tPvK7TLwO7Q"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_LyWcAbzlEe2tPvK7TLwO7Q" x="420" y="-180" width="281" height="60"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_LyWcAbzlEe2tPvK7TLwO7Q" x="380" y="-180" width="361" height="60"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_Z86n0LzmEe2tPvK7TLwO7Q" type="Class_Shape" fontName="Segoe UI" fontHeight="6" fillColor="12621752">
       <eAnnotations xmi:id="_nxr_QLzmEe2tPvK7TLwO7Q" source="PapyrusCSSForceValue">
@@ -1890,7 +1890,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="_Z86n47zmEe2tPvK7TLwO7Q"/>
       </children>
       <element href="TapiStreamingGnmi.uml#_Z81vULzmEe2tPvK7TLwO7Q"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_Z86n0bzmEe2tPvK7TLwO7Q" x="400" y="-60" width="321" height="60"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_Z86n0bzmEe2tPvK7TLwO7Q" x="320" y="-60" width="481" height="60"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_PLFyELzoEe2tPvK7TLwO7Q" type="Class_Shape" fontName="Segoe UI" fontHeight="6" fillColor="12560536">
       <eAnnotations xmi:id="_V4oBELzoEe2tPvK7TLwO7Q" source="PapyrusCSSForceValue">
@@ -1997,7 +1997,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="_PLFyI7zoEe2tPvK7TLwO7Q"/>
       </children>
       <element href="TapiStreamingGnmi.uml#_PLA5kLzoEe2tPvK7TLwO7Q"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_PLFyEbzoEe2tPvK7TLwO7Q" x="420" y="-340" width="281"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_PLFyEbzoEe2tPvK7TLwO7Q" x="380" y="-340" width="361"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_jUyEMLzoEe2tPvK7TLwO7Q" type="Class_Shape" fontName="Segoe UI" fontHeight="6" fillColor="12560536">
       <eAnnotations xmi:id="_B8gwkLzrEe2tPvK7TLwO7Q" source="PapyrusCSSForceValue">
@@ -2142,7 +2142,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="_jUyrULzoEe2tPvK7TLwO7Q"/>
       </children>
       <element href="TapiStreamingGnmi.uml#_jUkBwLzoEe2tPvK7TLwO7Q"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_jUyEMbzoEe2tPvK7TLwO7Q" y="-340" width="221" height="121"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_jUyEMbzoEe2tPvK7TLwO7Q" x="-180" y="-340" width="301" height="121"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_dWfSELzuEe2tPvK7TLwO7Q" type="Comment_Shape" fontName="Segoe UI" fontHeight="6" fillColor="12560536">
       <eAnnotations xmi:id="_q-v3gLzuEe2tPvK7TLwO7Q" source="PapyrusCSSForceValue">
@@ -2152,7 +2152,7 @@
       </eAnnotations>
       <children xsi:type="notation:DecorationNode" xmi:id="_dWfSErzuEe2tPvK7TLwO7Q" type="Comment_BodyLabel"/>
       <element href="TapiStreamingGnmi.uml#_dWerALzuEe2tPvK7TLwO7Q"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_dWfSEbzuEe2tPvK7TLwO7Q" x="240" y="-720" width="141" height="21"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_dWfSEbzuEe2tPvK7TLwO7Q" x="-180" y="-720" width="201" height="21"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_UsxNwLzvEe2tPvK7TLwO7Q" type="DataType_Shape" fontName="Segoe UI" fontHeight="6" fillColor="12560536">
       <eAnnotations xmi:id="_b78xQLzvEe2tPvK7TLwO7Q" source="PapyrusCSSForceValue">
@@ -2253,7 +2253,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="_UsxNzrzvEe2tPvK7TLwO7Q"/>
       </children>
       <element href="TapiStreamingGnmi.uml#_UswmsLzvEe2tPvK7TLwO7Q"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_UsxNwbzvEe2tPvK7TLwO7Q" y="-200" width="221"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_UsxNwbzvEe2tPvK7TLwO7Q" x="-180" y="-200" width="301"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_GvHxgOi9Ee2WXqIYPh2wfQ" type="Class_Shape" fontName="Segoe UI" fontHeight="6" fillColor="12621752" lineColor="0">
       <eAnnotations xmi:id="_yEjxgOi9Ee2WXqIYPh2wfQ" source="PapyrusCSSForceValue">
@@ -2322,7 +2322,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="_GvKNzui9Ee2WXqIYPh2wfQ"/>
       </children>
       <element href="TapiStreamingGnmi.uml#_Gu2rwOi9Ee2WXqIYPh2wfQ"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_GvHxgei9Ee2WXqIYPh2wfQ" x="400" y="60" width="320" height="60"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_GvHxgei9Ee2WXqIYPh2wfQ" x="320" y="60" width="480" height="60"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_7wo0YEZ3Ee6bIJjw8ZnZGQ" type="Enumeration_Shape" fontName="Segoe UI" fontHeight="6" fillColor="10265827">
       <eAnnotations xmi:id="_Nl0GMEZ4Ee6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
@@ -2566,7 +2566,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="_7wqpl0Z3Ee6bIJjw8ZnZGQ"/>
       </children>
       <element href="TapiCommon.uml#_xnfcMEyXEe2yGsF8121Sxw"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_7wo0YUZ3Ee6bIJjw8ZnZGQ" x="1060" y="-260" width="161" height="441"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_7wo0YUZ3Ee6bIJjw8ZnZGQ" x="1360" y="-260" width="241" height="441"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_pKuzwEZ4Ee6bIJjw8ZnZGQ" type="Comment_Shape" fontName="Segoe UI" fontHeight="6" fillColor="10265827">
       <eAnnotations xmi:id="_s7UJcEZ4Ee6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
@@ -2576,7 +2576,7 @@
       </eAnnotations>
       <children xsi:type="notation:DecorationNode" xmi:id="_pKuzwkZ4Ee6bIJjw8ZnZGQ" type="Comment_BodyLabel"/>
       <element href="TapiStreamingGnmi.uml#_pKsXgEZ4Ee6bIJjw8ZnZGQ"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_pKuzwUZ4Ee6bIJjw8ZnZGQ" x="240" y="-520" width="141" height="21"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_pKuzwUZ4Ee6bIJjw8ZnZGQ" x="-180" y="-520" width="201" height="21"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_nDV08EcyEe6bIJjw8ZnZGQ" type="Enumeration_Shape" fontName="Segoe UI" fontHeight="6" fillColor="8905185">
       <eAnnotations xmi:id="_nDV08UcyEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
@@ -3045,7 +3045,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="_nDV2pUcyEe6bIJjw8ZnZGQ"/>
       </children>
       <element href="TapiStreamingGnmi.uml#__6_sAEcnEe6bIJjw8ZnZGQ"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_nDV2qUcyEe6bIJjw8ZnZGQ" x="740" y="-260" width="261" height="441"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_nDV2qUcyEe6bIJjw8ZnZGQ" x="940" y="-260" width="381" height="441"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_KSJrYFIQEe6m_d6KGfEFwg" type="Class_Shape" fontName="Segoe UI" fontHeight="6" fillColor="12621752">
       <eAnnotations xmi:id="_sV5dkFIQEe6m_d6KGfEFwg" source="PapyrusCSSForceValue">
@@ -3509,263 +3509,263 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="_KSJrc1IQEe6m_d6KGfEFwg"/>
       </children>
       <element href="TapiStreamingGnmi.uml#_KRgyMFIQEe6m_d6KGfEFwg"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_KSJrYVIQEe6m_d6KGfEFwg" x="440" y="320" width="381" height="201"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_KSJrYVIQEe6m_d6KGfEFwg" x="360" y="320" width="581" height="201"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_4_-5YFeIEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_4_-5YVeIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_4_-5Y1eIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_vx2WQGZ4Ee6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_vx2WQWZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_vx29UGZ4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_FCwpUKYBEe2n-fmfRwdlPg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4_-5YleIEe6mE7NoRC7Zaw" x="1160" y="320"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_vx2WQmZ4Ee6bwd8NmC1HOg" x="1160" y="320"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_5Af2wFeIEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_5Af2wVeIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5Af2w1eIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_vyvHEGZ4Ee6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_vyvHEWZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_vyvHE2Z4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_ZhiA0EOEEe6bIJjw8ZnZGQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_5Af2wleIEe6mE7NoRC7Zaw" x="1160" y="220"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_vyvHEmZ4Ee6bwd8NmC1HOg" x="1160" y="220"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_5AxjkFeIEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_5AxjkVeIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5AyKoFeIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_vzUV4GZ4Ee6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_vzUV4WZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_vzUV42Z4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_VET7gFISEe6m_d6KGfEFwg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_5AxjkleIEe6mE7NoRC7Zaw" x="1160" y="220"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_vzUV4mZ4Ee6bwd8NmC1HOg" x="1160" y="220"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_5BTvEFeIEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_5BTvEVeIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5BUWIFeIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_v0bJIGZ4Ee6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_v0bJIWZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_v0bJI2Z4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiOam.uml#_vnyfgF0IEeipas1p-rFJBA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_5BTvEleIEe6mE7NoRC7Zaw" x="1220" y="400"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_v0bJImZ4Ee6bwd8NmC1HOg" x="1220" y="400"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_5DOaoFeIEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_5DOaoVeIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5DOao1eIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_v3JF8GZ4Ee6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_v3JF8WZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_v3JtAGZ4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_406Q8KFhEe2n-fmfRwdlPg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_5DOaoleIEe6mE7NoRC7Zaw" x="580" y="580"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_v3JF8mZ4Ee6bwd8NmC1HOg" x="580" y="580"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_5E0WEFeIEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_5E0WEVeIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5E09IFeIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_v5czEGZ4Ee6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_v5czEWZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_v5czE2Z4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_Aow5sKFgEe2n-fmfRwdlPg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_5E0WEleIEe6mE7NoRC7Zaw" x="600" y="180"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_v5czEmZ4Ee6bwd8NmC1HOg" x="600" y="180"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_5FPM0FeIEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_5FPM0VeIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5FPM01eIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_v6CB4GZ4Ee6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_v6CB4WZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_v6CB42Z4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_SyXM4KYBEe2n-fmfRwdlPg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_5FPM0leIEe6mE7NoRC7Zaw" x="600" y="80"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_v6CB4mZ4Ee6bwd8NmC1HOg" x="600" y="80"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_5FbaEFeIEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_5FbaEVeIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5FbaE1eIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_v6c4oGZ4Ee6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_v6c4oWZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_v6c4o2Z4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#__d9xQEODEe6bIJjw8ZnZGQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_5FbaEleIEe6mE7NoRC7Zaw" x="600" y="80"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_v6c4omZ4Ee6bwd8NmC1HOg" x="600" y="80"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_5FnnUFeIEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_5FnnUVeIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5FnnU1eIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_v6q7EGZ4Ee6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_v6q7EWZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_v6q7E2Z4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_S1iBsFIQEe6m_d6KGfEFwg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_5FnnUleIEe6mE7NoRC7Zaw" x="600" y="80"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_v6q7EmZ4Ee6bwd8NmC1HOg" x="600" y="80"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_5F5UIFeIEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_5F5UIVeIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5F57MFeIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_v7G_8GZ4Ee6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_v7G_8WZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_v7G_82Z4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreaming.uml#_X9ay8LqKEemx9sMHf8Tuig"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_5F5UIleIEe6mE7NoRC7Zaw" x="620" y="-760"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_v7G_8mZ4Ee6bwd8NmC1HOg" x="620" y="-760"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_5GcGsFeIEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_5GcGsVeIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5GcGs1eIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_v8Q2gGZ4Ee6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_v8Q2gWZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_v8RdkGZ4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiOam.uml#_-2fMYF0KEeipas1p-rFJBA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_5GcGsleIEe6mE7NoRC7Zaw" x="1220" y="600"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_v8Q2gmZ4Ee6bwd8NmC1HOg" x="1220" y="600"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_5HnycFeIEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_5HnycVeIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5Hnyc1eIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_v-E0YGZ4Ee6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_v-E0YWZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_v-E0Y2Z4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiOam.uml#_RRNb8DU7Eem_pr37XaewKQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_5HnycleIEe6mE7NoRC7Zaw" x="1220" y="740"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_v-E0YmZ4Ee6bwd8NmC1HOg" x="1220" y="740"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_5IXZUFeIEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_5IXZUVeIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5IXZU1eIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_v_a4MGZ4Ee6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_v_a4MWZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_v_a4M2Z4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_5IXZUleIEe6mE7NoRC7Zaw" x="1020" y="640"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_v_a4MmZ4Ee6bwd8NmC1HOg" x="1020" y="640"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_5IzeMFeIEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_5IzeMVeIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5IzeM1eIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_wAl84GZ4Ee6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_wAl84WZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_wAl842Z4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiOam.uml#_CE0kkLwmEeSpn78DYJKtkA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_5IzeMleIEe6mE7NoRC7Zaw" x="1020" y="760"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_wAl84mZ4Ee6bwd8NmC1HOg" x="1020" y="760"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_5JQKIFeIEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_5JQKIVeIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5JQKI1eIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_wBjmMGZ4Ee6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_wBjmMWZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_wBjmM2Z4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_5JQKIleIEe6mE7NoRC7Zaw" x="1020" y="700"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_wBjmMmZ4Ee6bwd8NmC1HOg" x="1020" y="700"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_5KLXMFeIEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_5KLXMVeIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5KL-QFeIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_wCpyYGZ4Ee6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_wCpyYWZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_wCpyY2Z4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_UjNPoLzPEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_5KLXMleIEe6mE7NoRC7Zaw" x="620" y="-640"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_wCpyYmZ4Ee6bwd8NmC1HOg" x="620" y="-640"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_5KhVcFeIEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_5KhVcVeIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5KhVc1eIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_wDITgGZ4Ee6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_wDITgWZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_wDI6kGZ4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_yH00ALzjEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_5KhVcleIEe6mE7NoRC7Zaw" x="620" y="-740"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_wDITgmZ4Ee6bwd8NmC1HOg" x="620" y="-740"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_5Kp4UFeIEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_5Kp4UVeIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5Kp4U1eIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_wDVH0GZ4Ee6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_wDVH0WZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_wDVH02Z4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_CNum8LzsEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_5Kp4UleIEe6mE7NoRC7Zaw" x="620" y="-740"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_wDVH0mZ4Ee6bwd8NmC1HOg" x="620" y="-740"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_5LF9MFeIEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_5LF9MVeIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5LF9M1eIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_wEGj4GZ4Ee6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_wEGj4WZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_wEGj42Z4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_jAoQkLzREe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_5LF9MleIEe6mE7NoRC7Zaw" x="620" y="-520"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_wEGj4mZ4Ee6bwd8NmC1HOg" x="620" y="-520"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_5LipIFeIEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_5LipIVeIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5LipI1eIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_wFJswGZ4Ee6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_wFJswWZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_wFJsw2Z4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_OOMkoLzrEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_5LipIleIEe6mE7NoRC7Zaw" x="620" y="-620"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_wFJswmZ4Ee6bwd8NmC1HOg" x="620" y="-620"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_5LrMAFeIEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_5LrMAVeIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5LrMA1eIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_wFcAoGZ4Ee6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_wFcAoWZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_wFcnsGZ4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_Q6Dt8LzrEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_5LrMAleIEe6mE7NoRC7Zaw" x="620" y="-620"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_wFcAomZ4Ee6bwd8NmC1HOg" x="620" y="-620"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_5MBKQFeIEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_5MBKQVeIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5MBKQ1eIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_wGbfIGZ4Ee6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_wGbfIWZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_wGbfI2Z4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_LyQ8cLzlEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_5MBKQleIEe6mE7NoRC7Zaw" x="620" y="-180"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_wGbfImZ4Ee6bwd8NmC1HOg" x="620" y="-180"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_5MOloFeIEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_5MOloVeIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5MOlo1eIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_wG-4wGZ4Ee6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_wG-4wWZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_wG_f0GZ4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_zx-10EOEEe6bIJjw8ZnZGQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_5MOloleIEe6mE7NoRC7Zaw" x="620" y="-280"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_wG-4wmZ4Ee6bwd8NmC1HOg" x="620" y="-280"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_5Mkj4FeIEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_5Mkj4VeIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5Mkj41eIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_wHxi8GZ4Ee6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_wHxi8WZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_wHxi82Z4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_Z81vULzmEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_5Mkj4leIEe6mE7NoRC7Zaw" x="600" y="-60"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_wHxi8mZ4Ee6bwd8NmC1HOg" x="600" y="-60"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_5M3e0FeIEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_5M3e0VeIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5M3e01eIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_wIkNIGZ4Ee6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_wIkNIWZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_wIkNI2Z4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_LqfOkLznEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_5M3e0leIEe6mE7NoRC7Zaw" x="600" y="-160"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_wIkNImZ4Ee6bwd8NmC1HOg" x="600" y="-160"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_5NM2AFeIEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_5NM2AVeIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5NM2A1eIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_wJahsGZ4Ee6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_wJahsWZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_wJahs2Z4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_PLA5kLzoEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_5NM2AleIEe6mE7NoRC7Zaw" x="620" y="-340"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_wJahsmZ4Ee6bwd8NmC1HOg" x="620" y="-340"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_5NjbUFeIEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_5NjbUVeIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5NkCYFeIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_wKYLAGZ4Ee6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_wKYLAWZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_wKYyEGZ4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_aU9CcLzoEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_5NjbUleIEe6mE7NoRC7Zaw" x="620" y="-440"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_wKYLAmZ4Ee6bwd8NmC1HOg" x="620" y="-440"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_5NslQFeIEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_5NslQVeIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5NslQ1eIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_wKnbkGZ4Ee6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_wKnbkWZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_wKnbk2Z4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_R_-CkLzqEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_5NslQleIEe6mE7NoRC7Zaw" x="620" y="-440"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_wKnbkmZ4Ee6bwd8NmC1HOg" x="620" y="-440"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_5OEYsFeIEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_5OEYsVeIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5OEYs1eIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_wLe-QGZ4Ee6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_wLe-QWZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_wLe-Q2Z4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_jUkBwLzoEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_5OEYsleIEe6mE7NoRC7Zaw" x="200" y="-340"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_wLe-QmZ4Ee6bwd8NmC1HOg" x="200" y="-340"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_5PCpEFeIEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_5PCpEVeIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5PCpE1eIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_wNbfAGZ4Ee6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_wNbfAWZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_wNbfA2Z4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_Gu2rwOi9Ee2WXqIYPh2wfQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_5PCpEleIEe6mE7NoRC7Zaw" x="600" y="60"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_wNbfAmZ4Ee6bwd8NmC1HOg" x="600" y="60"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_5PU88FeIEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_5PU88VeIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5PVkAFeIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_wOSaoGZ4Ee6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_wOSaoWZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_wOTBsGZ4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_eQ-SQOi9Ee2WXqIYPh2wfQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_5PU88leIEe6mE7NoRC7Zaw" x="600" y="-40"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_wOSaomZ4Ee6bwd8NmC1HOg" x="600" y="-40"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_5Q2m8FeIEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_5Q2m8VeIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5Q2m81eIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_wRT5cGZ4Ee6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_wRT5cWZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_wRT5c2Z4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_KRgyMFIQEe6m_d6KGfEFwg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_5Q2m8leIEe6mE7NoRC7Zaw" x="640" y="320"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_wRT5cmZ4Ee6bwd8NmC1HOg" x="640" y="320"/>
     </children>
     <styles xsi:type="notation:StringValueStyle" xmi:id="_S30Q4bHDEe2tjo53LmkUFA" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xsi:type="notation:DiagramStyle" xmi:id="_S30Q4rHDEe2tjo53LmkUFA"/>
@@ -3807,7 +3807,7 @@
       <children xsi:type="notation:DecorationNode" xmi:id="_kiI9pLHDEe2tjo53LmkUFA" type="Association_TargetMultiplicityLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_kiI9pbHDEe2tjo53LmkUFA" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <element href="TapiStreamingGnmi.uml#_SyXM4KYBEe2n-fmfRwdlPg"/>
-        <layoutConstraint xsi:type="notation:Location" xmi:id="_kiI9prHDEe2tjo53LmkUFA" x="-15" y="-23"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_kiI9prHDEe2tjo53LmkUFA" x="-13" y="-24"/>
       </children>
       <styles xsi:type="notation:FontStyle" xmi:id="_kiI9p7HDEe2tjo53LmkUFA" fontName="Segoe UI" fontHeight="6"/>
       <element href="TapiStreamingGnmi.uml#_SyXM4KYBEe2n-fmfRwdlPg"/>
@@ -3839,11 +3839,11 @@
       </children>
       <children xsi:type="notation:DecorationNode" xmi:id="_bk32RLv4Ee2tPvK7TLwO7Q" type="Association_SourceMultiplicityLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_0EeXMEOIEe6bIJjw8ZnZGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xsi:type="notation:Location" xmi:id="_bk32Rbv4Ee2tPvK7TLwO7Q" x="21" y="20"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_bk32Rbv4Ee2tPvK7TLwO7Q" x="24" y="7"/>
       </children>
       <children xsi:type="notation:DecorationNode" xmi:id="_bk32Rrv4Ee2tPvK7TLwO7Q" type="Association_TargetMultiplicityLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_0V-W4EOIEe6bIJjw8ZnZGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xsi:type="notation:Location" xmi:id="_bk32R7v4Ee2tPvK7TLwO7Q" x="-21" y="-20"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_bk32R7v4Ee2tPvK7TLwO7Q" x="-29" y="-13"/>
       </children>
       <styles xsi:type="notation:FontStyle" xmi:id="_bk3PMbv4Ee2tPvK7TLwO7Q" fontName="Segoe UI" fontHeight="6"/>
       <element href="TapiStreamingGnmi.uml#_a8-IwLv4Ee2tPvK7TLwO7Q"/>
@@ -3875,11 +3875,11 @@
       </children>
       <children xsi:type="notation:DecorationNode" xmi:id="_if_1W7v4Ee2tPvK7TLwO7Q" type="Association_SourceMultiplicityLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_1q_pEEOIEe6bIJjw8ZnZGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xsi:type="notation:Location" xmi:id="_if_1XLv4Ee2tPvK7TLwO7Q" x="21" y="20"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_if_1XLv4Ee2tPvK7TLwO7Q" x="24" y="7"/>
       </children>
       <children xsi:type="notation:DecorationNode" xmi:id="_if_1Xbv4Ee2tPvK7TLwO7Q" type="Association_TargetMultiplicityLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_171hcEOIEe6bIJjw8ZnZGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xsi:type="notation:Location" xmi:id="_if_1Xrv4Ee2tPvK7TLwO7Q" x="-21" y="-20"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_if_1Xrv4Ee2tPvK7TLwO7Q" x="-29" y="-13"/>
       </children>
       <styles xsi:type="notation:FontStyle" xmi:id="_if_1Ubv4Ee2tPvK7TLwO7Q" fontName="Segoe UI" fontHeight="6"/>
       <element href="TapiStreamingGnmi.uml#_h4IkELv4Ee2tPvK7TLwO7Q"/>
@@ -3911,11 +3911,11 @@
       </children>
       <children xsi:type="notation:DecorationNode" xmi:id="_k_joC7v4Ee2tPvK7TLwO7Q" type="Association_SourceMultiplicityLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_dDiRAEJdEe6tO8bOoJ4-CQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xsi:type="notation:Location" xmi:id="_k_joDLv4Ee2tPvK7TLwO7Q" x="21" y="20"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_k_joDLv4Ee2tPvK7TLwO7Q" x="24" y="7"/>
       </children>
       <children xsi:type="notation:DecorationNode" xmi:id="_k_joDbv4Ee2tPvK7TLwO7Q" type="Association_TargetMultiplicityLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_dbNxMEJdEe6tO8bOoJ4-CQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xsi:type="notation:Location" xmi:id="_k_joDrv4Ee2tPvK7TLwO7Q" x="-21" y="-20"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_k_joDrv4Ee2tPvK7TLwO7Q" x="-29" y="-13"/>
       </children>
       <styles xsi:type="notation:FontStyle" xmi:id="_k_joAbv4Ee2tPvK7TLwO7Q" fontName="Segoe UI" fontHeight="6"/>
       <element href="TapiStreamingGnmi.uml#_kXUjULv4Ee2tPvK7TLwO7Q"/>
@@ -3967,11 +3967,11 @@
       </children>
       <children xsi:type="notation:DecorationNode" xmi:id="_MKdIFLznEe2tPvK7TLwO7Q" type="Association_SourceMultiplicityLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_y7mOwLztEe2tPvK7TLwO7Q" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xsi:type="notation:Location" xmi:id="_MKdIFbznEe2tPvK7TLwO7Q" x="5" y="37"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_MKdIFbznEe2tPvK7TLwO7Q" x="7" y="15"/>
       </children>
       <children xsi:type="notation:DecorationNode" xmi:id="_MKdIFrznEe2tPvK7TLwO7Q" type="Association_TargetMultiplicityLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_zfpXALztEe2tPvK7TLwO7Q" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xsi:type="notation:Location" xmi:id="_MKdIF7znEe2tPvK7TLwO7Q" x="-15" y="33"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_MKdIF7znEe2tPvK7TLwO7Q" x="-13" y="-31"/>
       </children>
       <styles xsi:type="notation:FontStyle" xmi:id="_MKchAbznEe2tPvK7TLwO7Q" fontName="Segoe UI" fontHeight="6"/>
       <element href="TapiStreamingGnmi.uml#_LqfOkLznEe2tPvK7TLwO7Q"/>
@@ -4003,11 +4003,11 @@
       </children>
       <children xsi:type="notation:DecorationNode" xmi:id="_a1aEKrzoEe2tPvK7TLwO7Q" type="Association_SourceMultiplicityLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_WFQSYLzpEe2tPvK7TLwO7Q" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xsi:type="notation:Location" xmi:id="_a1aEK7zoEe2tPvK7TLwO7Q" x="5" y="17"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_a1aEK7zoEe2tPvK7TLwO7Q" x="7" y="15"/>
       </children>
       <children xsi:type="notation:DecorationNode" xmi:id="_a1aELLzoEe2tPvK7TLwO7Q" type="Association_TargetMultiplicityLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_WoBBMLzpEe2tPvK7TLwO7Q" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xsi:type="notation:Location" xmi:id="_a1aELbzoEe2tPvK7TLwO7Q" x="-16" y="-19"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_a1aELbzoEe2tPvK7TLwO7Q" x="-13" y="-31"/>
       </children>
       <styles xsi:type="notation:FontStyle" xmi:id="_a1aEILzoEe2tPvK7TLwO7Q" fontName="Segoe UI" fontHeight="6"/>
       <element href="TapiStreamingGnmi.uml#_aU9CcLzoEe2tPvK7TLwO7Q"/>
@@ -4039,11 +4039,11 @@
       </children>
       <children xsi:type="notation:DecorationNode" xmi:id="_ShHn27zqEe2tPvK7TLwO7Q" type="Association_SourceMultiplicityLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_dd0JcLzrEe2tPvK7TLwO7Q" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xsi:type="notation:Location" xmi:id="_ShHn3LzqEe2tPvK7TLwO7Q" x="10" y="17"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_ShHn3LzqEe2tPvK7TLwO7Q" x="35" y="13"/>
       </children>
       <children xsi:type="notation:DecorationNode" xmi:id="_ShHn3bzqEe2tPvK7TLwO7Q" type="Association_TargetMultiplicityLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_eA-g4LzrEe2tPvK7TLwO7Q" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xsi:type="notation:Location" xmi:id="_ShHn3rzqEe2tPvK7TLwO7Q" x="-11" y="-19"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_ShHn3rzqEe2tPvK7TLwO7Q" x="-30" y="-7"/>
       </children>
       <styles xsi:type="notation:FontStyle" xmi:id="_ShHn0bzqEe2tPvK7TLwO7Q" fontName="Segoe UI" fontHeight="6"/>
       <element href="TapiStreamingGnmi.uml#_R_-CkLzqEe2tPvK7TLwO7Q"/>
@@ -4075,11 +4075,11 @@
       </children>
       <children xsi:type="notation:DecorationNode" xmi:id="_Ouue27zrEe2tPvK7TLwO7Q" type="Association_SourceMultiplicityLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_2mNUwLzsEe2tPvK7TLwO7Q" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xsi:type="notation:Location" xmi:id="_Ouue3LzrEe2tPvK7TLwO7Q" x="4" y="17"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_Ouue3LzrEe2tPvK7TLwO7Q" x="6" y="19"/>
       </children>
       <children xsi:type="notation:DecorationNode" xmi:id="_Ouue3bzrEe2tPvK7TLwO7Q" type="Association_TargetMultiplicityLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_3ivOcLzsEe2tPvK7TLwO7Q" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xsi:type="notation:Location" xmi:id="_OuvF4LzrEe2tPvK7TLwO7Q" x="-15" y="-27"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_OuvF4LzrEe2tPvK7TLwO7Q" x="-13" y="-24"/>
       </children>
       <styles xsi:type="notation:FontStyle" xmi:id="_Ouue0bzrEe2tPvK7TLwO7Q" fontName="Segoe UI" fontHeight="6"/>
       <element href="TapiStreamingGnmi.uml#_OOMkoLzrEe2tPvK7TLwO7Q"/>
@@ -4115,13 +4115,13 @@
       </children>
       <children xsi:type="notation:DecorationNode" xmi:id="_RaPC0LzrEe2tPvK7TLwO7Q" type="Association_TargetMultiplicityLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_hFZUILzrEe2tPvK7TLwO7Q" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xsi:type="notation:Location" xmi:id="_RaPC0bzrEe2tPvK7TLwO7Q" x="-29" y="-20"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_RaPC0bzrEe2tPvK7TLwO7Q" x="-13" y="-31"/>
       </children>
       <styles xsi:type="notation:FontStyle" xmi:id="_RaObwbzrEe2tPvK7TLwO7Q" fontName="Segoe UI" fontHeight="6"/>
       <element href="TapiStreamingGnmi.uml#_Q6Dt8LzrEe2tPvK7TLwO7Q"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_RaObwrzrEe2tPvK7TLwO7Q" points="[420, -440, -643984, -643984]$[160, -440, -643984, -643984]$[160, -340, -643984, -643984]"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_RaObwrzrEe2tPvK7TLwO7Q" points="[420, -440, -643984, -643984]$[-20, -440, -643984, -643984]$[-20, -340, -643984, -643984]"/>
       <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_SevMwLzrEe2tPvK7TLwO7Q" id="(0.0,0.6611570247933884)"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_SevMwbzrEe2tPvK7TLwO7Q" id="(0.7239819004524887,0.0)"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_SevMwbzrEe2tPvK7TLwO7Q" id="(0.53156146179402,0.0)"/>
     </edges>
     <edges xsi:type="notation:Connector" xmi:id="_C16oULzsEe2tPvK7TLwO7Q" type="Association_Edge" source="_Uje8cLzPEe2tPvK7TLwO7Q" target="_jAwzcLzREe2tPvK7TLwO7Q">
       <eAnnotations xmi:id="_lizBoLztEe2tPvK7TLwO7Q" source="PapyrusCSSForceValue">
@@ -4183,11 +4183,11 @@
       </children>
       <children xsi:type="notation:DecorationNode" xmi:id="_e02baOi9Ee2WXqIYPh2wfQ" type="Association_SourceMultiplicityLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_4ETtcOi9Ee2WXqIYPh2wfQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xsi:type="notation:Location" xmi:id="_e02baei9Ee2WXqIYPh2wfQ" x="9" y="20"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_e02baei9Ee2WXqIYPh2wfQ" x="7" y="15"/>
       </children>
       <children xsi:type="notation:DecorationNode" xmi:id="_e02baui9Ee2WXqIYPh2wfQ" type="Association_TargetMultiplicityLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_4uO0MOi9Ee2WXqIYPh2wfQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xsi:type="notation:Location" xmi:id="_e02ba-i9Ee2WXqIYPh2wfQ" x="-10" y="-20"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_e02ba-i9Ee2WXqIYPh2wfQ" x="-13" y="-31"/>
       </children>
       <styles xsi:type="notation:FontStyle" xmi:id="_e010Uei9Ee2WXqIYPh2wfQ" fontName="Segoe UI" fontHeight="6"/>
       <element href="TapiStreamingGnmi.uml#_eQ-SQOi9Ee2WXqIYPh2wfQ"/>
@@ -4219,7 +4219,7 @@
       </children>
       <children xsi:type="notation:DecorationNode" xmi:id="__xjbq0ODEe6bIJjw8ZnZGQ" type="Association_SourceMultiplicityLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_7V88YFIQEe6m_d6KGfEFwg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xsi:type="notation:Location" xmi:id="__xjbrEODEe6bIJjw8ZnZGQ" x="5" y="13"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="__xjbrEODEe6bIJjw8ZnZGQ" x="7" y="29"/>
       </children>
       <children xsi:type="notation:DecorationNode" xmi:id="__xjbrUODEe6bIJjw8ZnZGQ" type="Association_TargetMultiplicityLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_7qJqwFIQEe6m_d6KGfEFwg" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -4228,8 +4228,8 @@
       <styles xsi:type="notation:FontStyle" xmi:id="__xjboUODEe6bIJjw8ZnZGQ" fontName="Segoe UI" fontHeight="6"/>
       <element href="TapiStreamingGnmi.uml#__d9xQEODEe6bIJjw8ZnZGQ"/>
       <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="__xjbokODEe6bIJjw8ZnZGQ" points="[480, 240, -643984, -643984]$[460, 340, -643984, -643984]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_AYSrgEOEEe6bIJjw8ZnZGQ" id="(0.06230529595015576,1.0)"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_AYSrgUOEEe6bIJjw8ZnZGQ" id="(0.10498687664041995,0.0)"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_AYSrgEOEEe6bIJjw8ZnZGQ" id="(0.04158004158004158,1.0)"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_AYSrgUOEEe6bIJjw8ZnZGQ" id="(0.06884681583476764,0.0)"/>
     </edges>
     <edges xsi:type="notation:Connector" xmi:id="_Z1cbUEOEEe6bIJjw8ZnZGQ" type="Association_Edge" source="_kiIW4bHDEe2tjo53LmkUFA" target="_kiLZ0LHDEe2tjo53LmkUFA" routing="Rectilinear">
       <eAnnotations xmi:id="_lkjGwEOEEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
@@ -4255,15 +4255,15 @@
       </children>
       <children xsi:type="notation:DecorationNode" xmi:id="_Z1cbW0OEEe6bIJjw8ZnZGQ" type="Association_SourceMultiplicityLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_PWD5EEOJEe6bIJjw8ZnZGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xsi:type="notation:Location" xmi:id="_Z1cbXEOEEe6bIJjw8ZnZGQ" x="13" y="-5"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_Z1cbXEOEEe6bIJjw8ZnZGQ" x="29" y="-7"/>
       </children>
       <children xsi:type="notation:DecorationNode" xmi:id="_Z1cbXUOEEe6bIJjw8ZnZGQ" type="Association_TargetMultiplicityLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_PmwAcEOJEe6bIJjw8ZnZGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xsi:type="notation:Location" xmi:id="_Z1cbXkOEEe6bIJjw8ZnZGQ" x="-26" y="-5"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_Z1cbXkOEEe6bIJjw8ZnZGQ" x="-24" y="-7"/>
       </children>
       <styles xsi:type="notation:FontStyle" xmi:id="_Z1cbUUOEEe6bIJjw8ZnZGQ" fontName="Segoe UI" fontHeight="6"/>
       <element href="TapiStreamingGnmi.uml#_ZhiA0EOEEe6bIJjw8ZnZGQ"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_Z1cbUkOEEe6bIJjw8ZnZGQ" points="[960, 380, -643984, -643984]$[920, 380, -643984, -643984]$[920, 600, -643984, -643984]$[761, 600, -643984, -643984]"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_Z1cbUkOEEe6bIJjw8ZnZGQ" points="[1300, 360, -643984, -643984]$[1080, 360, -643984, -643984]$[1080, 600, -643984, -643984]$[881, 600, -643984, -643984]"/>
       <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_adTFgEOEEe6bIJjw8ZnZGQ" id="(0.0,0.6557377049180327)"/>
       <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_adTFgUOEEe6bIJjw8ZnZGQ" id="(1.0,0.09049773755656108)"/>
     </edges>
@@ -4291,11 +4291,11 @@
       </children>
       <children xsi:type="notation:DecorationNode" xmi:id="_0FOh-0OEEe6bIJjw8ZnZGQ" type="Association_SourceMultiplicityLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_5xVwMEOEEe6bIJjw8ZnZGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xsi:type="notation:Location" xmi:id="_0FOh_EOEEe6bIJjw8ZnZGQ" x="6" y="20"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_0FOh_EOEEe6bIJjw8ZnZGQ" x="7" y="15"/>
       </children>
       <children xsi:type="notation:DecorationNode" xmi:id="_0FOh_UOEEe6bIJjw8ZnZGQ" type="Association_TargetMultiplicityLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_6EkOMEOEEe6bIJjw8ZnZGQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xsi:type="notation:Location" xmi:id="_0FOh_kOEEe6bIJjw8ZnZGQ" x="-6" y="-20"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_0FOh_kOEEe6bIJjw8ZnZGQ" x="-13" y="-31"/>
       </children>
       <styles xsi:type="notation:FontStyle" xmi:id="_0FOh8UOEEe6bIJjw8ZnZGQ" fontName="Segoe UI" fontHeight="6"/>
       <element href="TapiStreamingGnmi.uml#_zx-10EOEEe6bIJjw8ZnZGQ"/>
@@ -4327,17 +4327,17 @@
       </children>
       <children xsi:type="notation:DecorationNode" xmi:id="_TKgzOlIQEe6m_d6KGfEFwg" type="Association_SourceMultiplicityLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_wrpV0FIQEe6m_d6KGfEFwg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xsi:type="notation:Location" xmi:id="_TKgzO1IQEe6m_d6KGfEFwg" x="3" y="19"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_TKgzO1IQEe6m_d6KGfEFwg" x="7" y="29"/>
       </children>
       <children xsi:type="notation:DecorationNode" xmi:id="_TKgzPFIQEe6m_d6KGfEFwg" type="Association_TargetMultiplicityLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_xATXMFIQEe6m_d6KGfEFwg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xsi:type="notation:Location" xmi:id="_TKgzPVIQEe6m_d6KGfEFwg" x="-5" y="-19"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_TKgzPVIQEe6m_d6KGfEFwg" x="-13" y="-25"/>
       </children>
       <styles xsi:type="notation:FontStyle" xmi:id="_TKgzMFIQEe6m_d6KGfEFwg" fontName="Segoe UI" fontHeight="6"/>
       <element href="TapiStreamingGnmi.uml#_S1iBsFIQEe6m_d6KGfEFwg"/>
       <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_TKgzMVIQEe6m_d6KGfEFwg" points="[440, 240, -643984, -643984]$[380, 260, -643984, -643984]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_TzrE8FIQEe6m_d6KGfEFwg" id="(0.5607476635514018,1.0)"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_TzrE8VIQEe6m_d6KGfEFwg" id="(0.3674540682414698,0.0)"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_TzrE8FIQEe6m_d6KGfEFwg" id="(0.498960498960499,1.0)"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_TzrE8VIQEe6m_d6KGfEFwg" id="(0.3442340791738382,0.0)"/>
     </edges>
     <edges xsi:type="notation:Connector" xmi:id="_VYA6oFISEe6m_d6KGfEFwg" type="Association_Edge" source="_kiIW4bHDEe2tjo53LmkUFA" target="_KSJrYFIQEe6m_d6KGfEFwg">
       <eAnnotations xmi:id="_foxYwFISEe6m_d6KGfEFwg" source="PapyrusCSSForceValue">
@@ -4363,11 +4363,11 @@
       </children>
       <children xsi:type="notation:DecorationNode" xmi:id="_VYA6q1ISEe6m_d6KGfEFwg" type="Association_SourceMultiplicityLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_fQXqYFITEe6m_d6KGfEFwg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xsi:type="notation:Location" xmi:id="_VYA6rFISEe6m_d6KGfEFwg" x="16" y="-5"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_VYA6rFISEe6m_d6KGfEFwg" x="29" y="-7"/>
       </children>
       <children xsi:type="notation:DecorationNode" xmi:id="_VYA6rVISEe6m_d6KGfEFwg" type="Association_TargetMultiplicityLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_fpeG4FITEe6m_d6KGfEFwg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xsi:type="notation:Location" xmi:id="_VYA6rlISEe6m_d6KGfEFwg" x="-22" y="-5"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_VYA6rlISEe6m_d6KGfEFwg" x="-24" y="-7"/>
       </children>
       <styles xsi:type="notation:FontStyle" xmi:id="_VYA6oVISEe6m_d6KGfEFwg" fontName="Segoe UI" fontHeight="6"/>
       <element href="TapiStreamingGnmi.uml#_VET7gFISEe6m_d6KGfEFwg"/>
@@ -4375,325 +4375,325 @@
       <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_WE1kYFISEe6m_d6KGfEFwg" id="(0.0,0.32786885245901637)"/>
       <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_WE1kYVISEe6m_d6KGfEFwg" id="(1.0,0.09950248756218906)"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_4__gcFeIEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_kiIW4bHDEe2tjo53LmkUFA" target="_4_-5YFeIEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_4__gcVeIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_4__gdVeIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_vx710GZ4Ee6bwd8NmC1HOg" type="StereotypeCommentLink" source="_kiIW4bHDEe2tjo53LmkUFA" target="_vx2WQGZ4Ee6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_vx710WZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_vx8c4mZ4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_FCwpUKYBEe2n-fmfRwdlPg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_4__gcleIEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_4__gc1eIEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_4__gdFeIEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_vx710mZ4Ee6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_vx8c4GZ4Ee6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_vx8c4WZ4Ee6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_5Af2xFeIEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_Z1cbUEOEEe6bIJjw8ZnZGQ" target="_5Af2wFeIEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_5Af2xVeIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5Agd0FeIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_vyvHFGZ4Ee6bwd8NmC1HOg" type="StereotypeCommentLink" source="_Z1cbUEOEEe6bIJjw8ZnZGQ" target="_vyvHEGZ4Ee6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_vyvHFWZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_vyvuIGZ4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_ZhiA0EOEEe6bIJjw8ZnZGQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_5Af2xleIEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5Af2x1eIEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5Af2yFeIEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_vyvHFmZ4Ee6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_vyvHF2Z4Ee6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_vyvHGGZ4Ee6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_5AyKoVeIEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_VYA6oFISEe6m_d6KGfEFwg" target="_5AxjkFeIEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_5AyKoleIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5AyKpleIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_vzUV5GZ4Ee6bwd8NmC1HOg" type="StereotypeCommentLink" source="_VYA6oFISEe6m_d6KGfEFwg" target="_vzUV4GZ4Ee6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_vzUV5WZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_vzU88GZ4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_VET7gFISEe6m_d6KGfEFwg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_5AyKo1eIEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5AyKpFeIEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5AyKpVeIEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_vzUV5mZ4Ee6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_vzUV52Z4Ee6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_vzUV6GZ4Ee6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_5BUWIVeIEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_kiI9q7HDEe2tjo53LmkUFA" target="_5BTvEFeIEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_5BUWIleIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5BUWJleIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_v0bwMGZ4Ee6bwd8NmC1HOg" type="StereotypeCommentLink" source="_kiI9q7HDEe2tjo53LmkUFA" target="_v0bJIGZ4Ee6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_v0bwMWZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_v0bwNWZ4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiOam.uml#_vnyfgF0IEeipas1p-rFJBA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_5BUWI1eIEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5BUWJFeIEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5BUWJVeIEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_v0bwMmZ4Ee6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_v0bwM2Z4Ee6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_v0bwNGZ4Ee6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_5DOapFeIEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_kiLZ0LHDEe2tjo53LmkUFA" target="_5DOaoFeIEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_5DOapVeIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5DOaqVeIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_v3JtAWZ4Ee6bwd8NmC1HOg" type="StereotypeCommentLink" source="_kiLZ0LHDEe2tjo53LmkUFA" target="_v3JF8GZ4Ee6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_v3JtAmZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_v3JtBmZ4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_406Q8KFhEe2n-fmfRwdlPg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_5DOapleIEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5DOap1eIEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5DOaqFeIEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_v3JtA2Z4Ee6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_v3JtBGZ4Ee6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_v3JtBWZ4Ee6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_5E09IVeIEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_kiOdILHDEe2tjo53LmkUFA" target="_5E0WEFeIEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_5E09IleIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5E09JleIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_v5czFGZ4Ee6bwd8NmC1HOg" type="StereotypeCommentLink" source="_kiOdILHDEe2tjo53LmkUFA" target="_v5czEGZ4Ee6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_v5czFWZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_v5daIWZ4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_Aow5sKFgEe2n-fmfRwdlPg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_5E09I1eIEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5E09JFeIEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5E09JVeIEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_v5czFmZ4Ee6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_v5czF2Z4Ee6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_v5daIGZ4Ee6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_5FPM1FeIEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_kiI9kLHDEe2tjo53LmkUFA" target="_5FPM0FeIEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_5FPM1VeIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5FPz4leIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_v6Co8GZ4Ee6bwd8NmC1HOg" type="StereotypeCommentLink" source="_kiI9kLHDEe2tjo53LmkUFA" target="_v6CB4GZ4Ee6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_v6Co8WZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_v6Co9WZ4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_SyXM4KYBEe2n-fmfRwdlPg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_5FPM1leIEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5FPz4FeIEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5FPz4VeIEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_v6Co8mZ4Ee6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_v6Co82Z4Ee6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_v6Co9GZ4Ee6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_5FbaFFeIEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="__xjboEODEe6bIJjw8ZnZGQ" target="_5FbaEFeIEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_5FbaFVeIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5FcBIFeIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_v6dfsGZ4Ee6bwd8NmC1HOg" type="StereotypeCommentLink" source="__xjboEODEe6bIJjw8ZnZGQ" target="_v6c4oGZ4Ee6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_v6dfsWZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_v6dftWZ4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#__d9xQEODEe6bIJjw8ZnZGQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_5FbaFleIEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5FbaF1eIEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5FbaGFeIEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_v6dfsmZ4Ee6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_v6dfs2Z4Ee6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_v6dftGZ4Ee6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_5FnnVFeIEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_TKgMIFIQEe6m_d6KGfEFwg" target="_5FnnUFeIEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_5FnnVVeIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5FnnWVeIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_v6q7FGZ4Ee6bwd8NmC1HOg" type="StereotypeCommentLink" source="_TKgMIFIQEe6m_d6KGfEFwg" target="_v6q7EGZ4Ee6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_v6q7FWZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_v6q7GWZ4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_S1iBsFIQEe6m_d6KGfEFwg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_5FnnVleIEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5FnnV1eIEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5FnnWFeIEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_v6q7FmZ4Ee6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_v6q7F2Z4Ee6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_v6q7GGZ4Ee6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_5F57MVeIEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_q9G14LHDEe2tjo53LmkUFA" target="_5F5UIFeIEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_5F57MleIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5F57NleIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_v7G_9GZ4Ee6bwd8NmC1HOg" type="StereotypeCommentLink" source="_q9G14LHDEe2tjo53LmkUFA" target="_v7G_8GZ4Ee6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_v7G_9WZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_v7HnAGZ4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreaming.uml#_X9ay8LqKEemx9sMHf8Tuig"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_5F57M1eIEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5F57NFeIEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5F57NVeIEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_v7G_9mZ4Ee6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_v7G_92Z4Ee6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_v7G_-GZ4Ee6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_5GcGtFeIEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_7AfSkLHGEe2tjo53LmkUFA" target="_5GcGsFeIEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_5GcGtVeIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5GctwFeIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_v8RdkWZ4Ee6bwd8NmC1HOg" type="StereotypeCommentLink" source="_7AfSkLHGEe2tjo53LmkUFA" target="_v8Q2gGZ4Ee6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_v8RdkmZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_v8RdlmZ4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiOam.uml#_-2fMYF0KEeipas1p-rFJBA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_5GcGtleIEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5GcGt1eIEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5GcGuFeIEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_v8Rdk2Z4Ee6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_v8RdlGZ4Ee6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_v8RdlWZ4Ee6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_5HoZgFeIEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_Z9c6ALHHEe2tjo53LmkUFA" target="_5HnycFeIEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_5HoZgVeIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5HoZhVeIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_v-E0ZGZ4Ee6bwd8NmC1HOg" type="StereotypeCommentLink" source="_Z9c6ALHHEe2tjo53LmkUFA" target="_v-E0YGZ4Ee6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_v-E0ZWZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_v-E0aWZ4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiOam.uml#_RRNb8DU7Eem_pr37XaewKQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_5HoZgleIEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5HoZg1eIEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5HoZhFeIEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_v-E0ZmZ4Ee6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_v-E0Z2Z4Ee6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_v-E0aGZ4Ee6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_5IXZVFeIEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_yn1tgLv2Ee2tPvK7TLwO7Q" target="_5IXZUFeIEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_5IXZVVeIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5IXZWVeIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_v_a4NGZ4Ee6bwd8NmC1HOg" type="StereotypeCommentLink" source="_yn1tgLv2Ee2tPvK7TLwO7Q" target="_v_a4MGZ4Ee6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_v_bfQGZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_v_bfRGZ4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_5IXZVleIEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5IXZV1eIEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5IXZWFeIEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_v_bfQWZ4Ee6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_v_bfQmZ4Ee6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_v_bfQ2Z4Ee6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_5IzeNFeIEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_266sQLv2Ee2tPvK7TLwO7Q" target="_5IzeMFeIEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_5IzeNVeIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5IzeOVeIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_wAmj8GZ4Ee6bwd8NmC1HOg" type="StereotypeCommentLink" source="_266sQLv2Ee2tPvK7TLwO7Q" target="_wAl84GZ4Ee6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_wAmj8WZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_wAmj9WZ4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiOam.uml#_CE0kkLwmEeSpn78DYJKtkA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_5IzeNleIEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5IzeN1eIEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5IzeOFeIEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_wAmj8mZ4Ee6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_wAmj82Z4Ee6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_wAmj9GZ4Ee6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_5JQKJFeIEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_5PZ3YLv2Ee2tPvK7TLwO7Q" target="_5JQKIFeIEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_5JQKJVeIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5JQKKVeIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_wBjmNGZ4Ee6bwd8NmC1HOg" type="StereotypeCommentLink" source="_5PZ3YLv2Ee2tPvK7TLwO7Q" target="_wBjmMGZ4Ee6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_wBjmNWZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_wBjmOWZ4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_5JQKJleIEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5JQKJ1eIEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5JQKKFeIEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_wBjmNmZ4Ee6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_wBjmN2Z4Ee6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_wBjmOGZ4Ee6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_5KL-QVeIEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_Uje8cLzPEe2tPvK7TLwO7Q" target="_5KLXMFeIEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_5KL-QleIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5KL-RleIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_wCpyZGZ4Ee6bwd8NmC1HOg" type="StereotypeCommentLink" source="_Uje8cLzPEe2tPvK7TLwO7Q" target="_wCpyYGZ4Ee6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_wCpyZWZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_wCpyaWZ4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_UjNPoLzPEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_5KL-Q1eIEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5KL-RFeIEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5KL-RVeIEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_wCpyZmZ4Ee6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_wCpyZ2Z4Ee6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_wCpyaGZ4Ee6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_5KhVdFeIEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_yH-lALzjEe2tPvK7TLwO7Q" target="_5KhVcFeIEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_5KhVdVeIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5KhVeVeIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_wDI6kWZ4Ee6bwd8NmC1HOg" type="StereotypeCommentLink" source="_yH-lALzjEe2tPvK7TLwO7Q" target="_wDITgGZ4Ee6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_wDI6kmZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_wDI6lmZ4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_yH00ALzjEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_5KhVdleIEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5KhVd1eIEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5KhVeFeIEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_wDI6k2Z4Ee6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_wDI6lGZ4Ee6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_wDI6lWZ4Ee6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_5Kp4VFeIEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_C16oULzsEe2tPvK7TLwO7Q" target="_5Kp4UFeIEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_5Kp4VVeIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5Kp4WVeIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_wDVH1GZ4Ee6bwd8NmC1HOg" type="StereotypeCommentLink" source="_C16oULzsEe2tPvK7TLwO7Q" target="_wDVH0GZ4Ee6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_wDVH1WZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_wDVH2WZ4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_CNum8LzsEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_5Kp4VleIEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5Kp4V1eIEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5Kp4WFeIEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_wDVH1mZ4Ee6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_wDVH12Z4Ee6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_wDVH2GZ4Ee6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_5LF9NFeIEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_jAwzcLzREe2tPvK7TLwO7Q" target="_5LF9MFeIEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_5LF9NVeIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5LF9OVeIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_wEGj5GZ4Ee6bwd8NmC1HOg" type="StereotypeCommentLink" source="_jAwzcLzREe2tPvK7TLwO7Q" target="_wEGj4GZ4Ee6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_wEGj5WZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_wEGj6WZ4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_jAoQkLzREe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_5LF9NleIEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5LF9N1eIEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5LF9OFeIEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_wEGj5mZ4Ee6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_wEGj52Z4Ee6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_wEGj6GZ4Ee6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_5LipJFeIEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_Ouue0LzrEe2tPvK7TLwO7Q" target="_5LipIFeIEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_5LipJVeIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5LipKVeIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_wFKT0GZ4Ee6bwd8NmC1HOg" type="StereotypeCommentLink" source="_Ouue0LzrEe2tPvK7TLwO7Q" target="_wFJswGZ4Ee6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_wFKT0WZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_wFKT1WZ4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_OOMkoLzrEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_5LipJleIEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5LipJ1eIEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5LipKFeIEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_wFKT0mZ4Ee6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_wFKT02Z4Ee6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_wFKT1GZ4Ee6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_5LrMBFeIEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_RaObwLzrEe2tPvK7TLwO7Q" target="_5LrMAFeIEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_5LrMBVeIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5LrMCVeIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_wFcnsWZ4Ee6bwd8NmC1HOg" type="StereotypeCommentLink" source="_RaObwLzrEe2tPvK7TLwO7Q" target="_wFcAoGZ4Ee6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_wFcnsmZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_wFcntmZ4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_Q6Dt8LzrEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_5LrMBleIEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5LrMB1eIEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5LrMCFeIEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_wFcns2Z4Ee6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_wFcntGZ4Ee6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_wFcntWZ4Ee6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_5MBKRFeIEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_LyWcALzlEe2tPvK7TLwO7Q" target="_5MBKQFeIEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_5MBKRVeIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5MBKSVeIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_wGbfJGZ4Ee6bwd8NmC1HOg" type="StereotypeCommentLink" source="_LyWcALzlEe2tPvK7TLwO7Q" target="_wGbfIGZ4Ee6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_wGbfJWZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_wGbfKWZ4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_LyQ8cLzlEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_5MBKRleIEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5MBKR1eIEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5MBKSFeIEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_wGbfJmZ4Ee6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_wGbfJ2Z4Ee6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_wGbfKGZ4Ee6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_5MOlpFeIEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_0FOh8EOEEe6bIJjw8ZnZGQ" target="_5MOloFeIEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_5MOlpVeIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5MPMsFeIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_wG_f0WZ4Ee6bwd8NmC1HOg" type="StereotypeCommentLink" source="_0FOh8EOEEe6bIJjw8ZnZGQ" target="_wG-4wGZ4Ee6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_wG_f0mZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_wG_f1mZ4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_zx-10EOEEe6bIJjw8ZnZGQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_5MOlpleIEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5MOlp1eIEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5MOlqFeIEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_wG_f02Z4Ee6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_wG_f1GZ4Ee6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_wG_f1WZ4Ee6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_5Mkj5FeIEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_Z86n0LzmEe2tPvK7TLwO7Q" target="_5Mkj4FeIEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_5Mkj5VeIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5MlK8FeIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_wHxi9GZ4Ee6bwd8NmC1HOg" type="StereotypeCommentLink" source="_Z86n0LzmEe2tPvK7TLwO7Q" target="_wHxi8GZ4Ee6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_wHxi9WZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_wHyKAmZ4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_Z81vULzmEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_5Mkj5leIEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5Mkj51eIEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5Mkj6FeIEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_wHxi9mZ4Ee6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_wHyKAGZ4Ee6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_wHyKAWZ4Ee6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_5M3e1FeIEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_MKchALznEe2tPvK7TLwO7Q" target="_5M3e0FeIEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_5M3e1VeIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5M4F4leIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_wIkNJGZ4Ee6bwd8NmC1HOg" type="StereotypeCommentLink" source="_MKchALznEe2tPvK7TLwO7Q" target="_wIkNIGZ4Ee6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_wIkNJWZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_wIk0MmZ4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_LqfOkLznEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_5M3e1leIEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5M4F4FeIEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5M4F4VeIEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_wIkNJmZ4Ee6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_wIk0MGZ4Ee6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_wIk0MWZ4Ee6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_5NM2BFeIEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_PLFyELzoEe2tPvK7TLwO7Q" target="_5NM2AFeIEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_5NM2BVeIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5NM2CVeIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_wJahtGZ4Ee6bwd8NmC1HOg" type="StereotypeCommentLink" source="_PLFyELzoEe2tPvK7TLwO7Q" target="_wJahsGZ4Ee6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_wJahtWZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_wJbIwmZ4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_PLA5kLzoEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_5NM2BleIEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5NM2B1eIEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5NM2CFeIEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_wJahtmZ4Ee6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_wJbIwGZ4Ee6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_wJbIwWZ4Ee6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_5NkCYVeIEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_a1ZdELzoEe2tPvK7TLwO7Q" target="_5NjbUFeIEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_5NkCYleIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5NkCZleIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_wKYyEWZ4Ee6bwd8NmC1HOg" type="StereotypeCommentLink" source="_a1ZdELzoEe2tPvK7TLwO7Q" target="_wKYLAGZ4Ee6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_wKYyEmZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_wKYyFmZ4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_aU9CcLzoEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_5NkCY1eIEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5NkCZFeIEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5NkCZVeIEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_wKYyE2Z4Ee6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_wKYyFGZ4Ee6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_wKYyFWZ4Ee6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_5NslRFeIEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_ShHn0LzqEe2tPvK7TLwO7Q" target="_5NslQFeIEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_5NslRVeIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5NslSVeIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_wKnblGZ4Ee6bwd8NmC1HOg" type="StereotypeCommentLink" source="_ShHn0LzqEe2tPvK7TLwO7Q" target="_wKnbkGZ4Ee6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_wKnblWZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_wKoComZ4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_R_-CkLzqEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_5NslRleIEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5NslR1eIEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5NslSFeIEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_wKnblmZ4Ee6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_wKoCoGZ4Ee6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_wKoCoWZ4Ee6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_5OEYtFeIEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_jUyEMLzoEe2tPvK7TLwO7Q" target="_5OEYsFeIEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_5OEYtVeIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5OEYuVeIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_wLe-RGZ4Ee6bwd8NmC1HOg" type="StereotypeCommentLink" source="_jUyEMLzoEe2tPvK7TLwO7Q" target="_wLe-QGZ4Ee6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_wLe-RWZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_wLflUWZ4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_jUkBwLzoEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_5OEYtleIEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5OEYt1eIEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5OEYuFeIEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_wLe-RmZ4Ee6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_wLe-R2Z4Ee6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_wLflUGZ4Ee6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_5PCpFFeIEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_GvHxgOi9Ee2WXqIYPh2wfQ" target="_5PCpEFeIEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_5PCpFVeIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5PCpGVeIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_wNbfBGZ4Ee6bwd8NmC1HOg" type="StereotypeCommentLink" source="_GvHxgOi9Ee2WXqIYPh2wfQ" target="_wNbfAGZ4Ee6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_wNbfBWZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_wNbfCWZ4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_Gu2rwOi9Ee2WXqIYPh2wfQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_5PCpFleIEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5PCpF1eIEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5PCpGFeIEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_wNbfBmZ4Ee6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_wNbfB2Z4Ee6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_wNbfCGZ4Ee6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_5PVkAVeIEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_e010UOi9Ee2WXqIYPh2wfQ" target="_5PU88FeIEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_5PVkAleIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5PVkBleIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_wOTBsWZ4Ee6bwd8NmC1HOg" type="StereotypeCommentLink" source="_e010UOi9Ee2WXqIYPh2wfQ" target="_wOSaoGZ4Ee6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_wOTBsmZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_wOTBtmZ4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_eQ-SQOi9Ee2WXqIYPh2wfQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_5PVkA1eIEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5PVkBFeIEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5PVkBVeIEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_wOTBs2Z4Ee6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_wOTBtGZ4Ee6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_wOTBtWZ4Ee6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_5Q2m9FeIEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_KSJrYFIQEe6m_d6KGfEFwg" target="_5Q2m8FeIEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_5Q2m9VeIEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_5Q2m-VeIEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_wRT5dGZ4Ee6bwd8NmC1HOg" type="StereotypeCommentLink" source="_KSJrYFIQEe6m_d6KGfEFwg" target="_wRT5cGZ4Ee6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_wRT5dWZ4Ee6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_wRVHkmZ4Ee6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_KRgyMFIQEe6m_d6KGfEFwg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_5Q2m9leIEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5Q2m91eIEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_5Q2m-FeIEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_wRT5dmZ4Ee6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_wRVHkGZ4Ee6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_wRVHkWZ4Ee6bwd8NmC1HOg"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_B8tVAEJaEe6tO8bOoJ4-CQ" type="PapyrusUMLClassDiagram" name="GnmiStreamStructure" measurementUnit="Pixel">
@@ -4705,7 +4705,7 @@
       </eAnnotations>
       <children xsi:type="notation:DecorationNode" xmi:id="_WyfRM0JaEe6tO8bOoJ4-CQ" type="Comment_BodyLabel"/>
       <element href="TapiStreamingGnmi.uml#_dWerALzuEe2tPvK7TLwO7Q"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_WyfRNEJaEe6tO8bOoJ4-CQ" x="280" y="-820" width="181" height="41"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_WyfRNEJaEe6tO8bOoJ4-CQ" x="-140" y="-820" width="201" height="41"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_WyfRU0JaEe6tO8bOoJ4-CQ" type="Class_Shape" fontName="Segoe UI" fontHeight="6" fillColor="12560536">
       <eAnnotations xmi:id="_WyfRVEJaEe6tO8bOoJ4-CQ" source="PapyrusCSSForceValue">
@@ -4850,7 +4850,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="_WyfSBUJaEe6tO8bOoJ4-CQ"/>
       </children>
       <element href="TapiStreamingGnmi.uml#_jUkBwLzoEe2tPvK7TLwO7Q"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_WyfSL0JaEe6tO8bOoJ4-CQ" x="20" y="-340" width="220"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_WyfSL0JaEe6tO8bOoJ4-CQ" x="-140" y="-340" width="300"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_WypCTEJaEe6tO8bOoJ4-CQ" type="Comment_Shape" fontName="Segoe UI" fontHeight="6" fillColor="8047085">
       <eAnnotations xmi:id="_WypCTUJaEe6tO8bOoJ4-CQ" source="PapyrusCSSForceValue">
@@ -4863,7 +4863,7 @@
         <element href="TapiStreamingGnmi.uml#_gcZyQN2TEeyisriSvKT5Lw"/>
       </children>
       <element href="TapiStreamingGnmi.uml#_gcZyQN2TEeyisriSvKT5Lw"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_WypCU0JaEe6tO8bOoJ4-CQ" x="280" y="-880" width="180" height="40"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_WypCU0JaEe6tO8bOoJ4-CQ" x="-140" y="-880" width="200" height="40"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_WypCVEJaEe6tO8bOoJ4-CQ" type="Signal_Shape" fontName="Segoe UI" fontHeight="6" fillColor="8047085">
       <eAnnotations xmi:id="_WypCVUJaEe6tO8bOoJ4-CQ" source="PapyrusCSSForceValue">
@@ -4882,7 +4882,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="_WypCYEJaEe6tO8bOoJ4-CQ"/>
       </children>
       <element href="TapiStreaming.uml#_X9ay8LqKEemx9sMHf8Tuig"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_WypCe0JaEe6tO8bOoJ4-CQ" x="480" y="-880" width="181" height="61"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_WypCe0JaEe6tO8bOoJ4-CQ" x="400" y="-880" width="361" height="61"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_WypCfEJaEe6tO8bOoJ4-CQ" type="Class_Shape" fontName="Segoe UI" fontHeight="6" fillColor="12560536">
       <eAnnotations xmi:id="_WypCfUJaEe6tO8bOoJ4-CQ" source="PapyrusCSSForceValue">
@@ -4913,7 +4913,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="_WypCkkJaEe6tO8bOoJ4-CQ"/>
       </children>
       <element href="TapiStreamingGnmi.uml#_LyQ8cLzlEe2tPvK7TLwO7Q"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_WypCvEJaEe6tO8bOoJ4-CQ" x="460" y="-160" width="241" height="60"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_WypCvEJaEe6tO8bOoJ4-CQ" x="400" y="-160" width="361" height="60"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_WypCvUJaEe6tO8bOoJ4-CQ" type="Class_Shape" fontName="Segoe UI" fontHeight="6" fillColor="12560536">
       <eAnnotations xmi:id="_WypCvkJaEe6tO8bOoJ4-CQ" source="PapyrusCSSForceValue">
@@ -5058,7 +5058,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="_WypDb0JaEe6tO8bOoJ4-CQ"/>
       </children>
       <element href="TapiStreamingGnmi.uml#_jAoQkLzREe2tPvK7TLwO7Q"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_WypDmUJaEe6tO8bOoJ4-CQ" x="440" y="-520" width="281" height="121"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_WypDmUJaEe6tO8bOoJ4-CQ" x="400" y="-520" width="361" height="121"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_WypDmkJaEe6tO8bOoJ4-CQ" type="DataType_Shape" fontName="Segoe UI" fontHeight="6" fillColor="12560536">
       <eAnnotations xmi:id="_WypDm0JaEe6tO8bOoJ4-CQ" source="PapyrusCSSForceValue">
@@ -5159,7 +5159,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="_WypEE0JaEe6tO8bOoJ4-CQ"/>
       </children>
       <element href="TapiStreamingGnmi.uml#_UswmsLzvEe2tPvK7TLwO7Q"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_WypEF0JaEe6tO8bOoJ4-CQ" x="20" y="-180" width="221"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_WypEF0JaEe6tO8bOoJ4-CQ" x="-140" y="-180" width="301"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_WypEGEJaEe6tO8bOoJ4-CQ" type="Class_Shape" fontName="Segoe UI" fontHeight="6" fillColor="12560536">
       <eAnnotations xmi:id="_WypEGUJaEe6tO8bOoJ4-CQ" source="PapyrusCSSForceValue">
@@ -5228,7 +5228,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="_WypEYkJaEe6tO8bOoJ4-CQ"/>
       </children>
       <element href="TapiStreamingGnmi.uml#_UjNPoLzPEe2tPvK7TLwO7Q"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_WypEjEJaEe6tO8bOoJ4-CQ" x="440" y="-680" width="281" height="81"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_WypEjEJaEe6tO8bOoJ4-CQ" x="400" y="-680" width="361" height="81"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_WypEwEJaEe6tO8bOoJ4-CQ" type="Class_Shape" fontName="Segoe UI" fontHeight="6" fillColor="12560536">
       <eAnnotations xmi:id="_WypEwUJaEe6tO8bOoJ4-CQ" source="PapyrusCSSForceValue">
@@ -5335,103 +5335,103 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="_WypFPkJaEe6tO8bOoJ4-CQ"/>
       </children>
       <element href="TapiStreamingGnmi.uml#_PLA5kLzoEe2tPvK7TLwO7Q"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_WypFaEJaEe6tO8bOoJ4-CQ" x="460" y="-340" width="241"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_WypFaEJaEe6tO8bOoJ4-CQ" x="400" y="-340" width="361"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_olBFqVITEe6m_d6KGfEFwg" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_olBFqlITEe6m_d6KGfEFwg"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_olBFrFITEe6m_d6KGfEFwg" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_OhHbwGaAEe6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_OhHbwWaAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_OhHbw2aAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_jUkBwLzoEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_olBFq1ITEe6m_d6KGfEFwg" x="220" y="-340"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_OhHbwmaAEe6bwd8NmC1HOg" x="220" y="-340"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_olVOrVITEe6m_d6KGfEFwg" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_olVOrlITEe6m_d6KGfEFwg"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_olVOsFITEe6m_d6KGfEFwg" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_OhWsYGaAEe6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_OhWsYWaAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_OhWsY2aAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreaming.uml#_X9ay8LqKEemx9sMHf8Tuig"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_olVOr1ITEe6m_d6KGfEFwg" x="680" y="-880"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_OhWsYmaAEe6bwd8NmC1HOg" x="680" y="-880"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_ole_o1ITEe6m_d6KGfEFwg" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_ole_pFITEe6m_d6KGfEFwg"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_ole_plITEe6m_d6KGfEFwg" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_OhpnQGaAEe6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_OhpnQWaAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_OhpnQ2aAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_LyQ8cLzlEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_ole_pVITEe6m_d6KGfEFwg" x="660" y="-160"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_OhpnQmaAEe6bwd8NmC1HOg" x="660" y="-160"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_olql11ITEe6m_d6KGfEFwg" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_olql2FITEe6m_d6KGfEFwg"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_olql2lITEe6m_d6KGfEFwg" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_OhzYS2aAEe6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_OhzYTGaAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_OhzYTmaAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_jAoQkLzREe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_olql2VITEe6m_d6KGfEFwg" x="640" y="-520"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_OhzYTWaAEe6bwd8NmC1HOg" x="640" y="-520"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_ol1lEVITEe6m_d6KGfEFwg" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_ol1lElITEe6m_d6KGfEFwg"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_ol1lFFITEe6m_d6KGfEFwg" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_OiIIY2aAEe6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_OiIIZGaAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_OiIIZmaAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_OOMkoLzrEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_ol1lE1ITEe6m_d6KGfEFwg" x="640" y="-620"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_OiIIZWaAEe6bwd8NmC1HOg" x="640" y="-620"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_ol1lIlITEe6m_d6KGfEFwg" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_ol1lI1ITEe6m_d6KGfEFwg"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_ol1lJVITEe6m_d6KGfEFwg" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_OiIIdGaAEe6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_OiIIdWaAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_OiIId2aAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_Q6Dt8LzrEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_ol1lJFITEe6m_d6KGfEFwg" x="640" y="-620"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_OiIIdmaAEe6bwd8NmC1HOg" x="640" y="-620"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_omH421ITEe6m_d6KGfEFwg" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_omH43FITEe6m_d6KGfEFwg"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_omH43lITEe6m_d6KGfEFwg" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_OibqcmaAEe6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_Oibqc2aAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_OibqdWaAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_UjNPoLzPEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_omH43VITEe6m_d6KGfEFwg" x="640" y="-680"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_OibqdGaAEe6bwd8NmC1HOg" x="640" y="-680"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_omSQ41ITEe6m_d6KGfEFwg" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_omSQ5FITEe6m_d6KGfEFwg"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_omSQ5lITEe6m_d6KGfEFwg" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_OiulUGaAEe6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_OiulUWaAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_OiulU2aAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_CNum8LzsEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_omSQ5VITEe6m_d6KGfEFwg" x="640" y="-780"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_OiulUmaAEe6bwd8NmC1HOg" x="640" y="-780"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_omSQ9FITEe6m_d6KGfEFwg" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_omSQ9VITEe6m_d6KGfEFwg"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_omSQ91ITEe6m_d6KGfEFwg" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_OiulYWaAEe6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_OiulYmaAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_OiulZGaAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_yH00ALzjEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_omSQ9lITEe6m_d6KGfEFwg" x="640" y="-780"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_OiulY2aAEe6bwd8NmC1HOg" x="640" y="-780"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_omcB61ITEe6m_d6KGfEFwg" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_omcB7FITEe6m_d6KGfEFwg"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_omcB7lITEe6m_d6KGfEFwg" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_Oi4WW2aAEe6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_Oi4WXGaAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_Oi4WXmaAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_PLA5kLzoEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_omcB7VITEe6m_d6KGfEFwg" x="660" y="-340"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_Oi4WXWaAEe6bwd8NmC1HOg" x="660" y="-340"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_ommaLFITEe6m_d6KGfEFwg" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_ommaLVITEe6m_d6KGfEFwg"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_ommaL1ITEe6m_d6KGfEFwg" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_OjL4UGaAEe6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_OjL4UWaAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_OjL4U2aAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_aU9CcLzoEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_ommaLlITEe6m_d6KGfEFwg" x="660" y="-440"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_OjL4UmaAEe6bwd8NmC1HOg" x="660" y="-440"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_ommaPVITEe6m_d6KGfEFwg" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_ommaPlITEe6m_d6KGfEFwg"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_ommaQFITEe6m_d6KGfEFwg" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_OjNGd2aAEe6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_OjNGeGaAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_OjNGemaAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_R_-CkLzqEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_ommaP1ITEe6m_d6KGfEFwg" x="660" y="-440"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_OjNGeWaAEe6bwd8NmC1HOg" x="660" y="-440"/>
     </children>
     <styles xsi:type="notation:StringValueStyle" xmi:id="_B8tVAUJaEe6tO8bOoJ4-CQ" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xsi:type="notation:DiagramStyle" xmi:id="_B8tVAkJaEe6tO8bOoJ4-CQ"/>
@@ -5467,7 +5467,7 @@
       </children>
       <children xsi:type="notation:DecorationNode" xmi:id="_WyfRJEJaEe6tO8bOoJ4-CQ" type="Association_TargetMultiplicityLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_WyfRJUJaEe6tO8bOoJ4-CQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xsi:type="notation:Location" xmi:id="_WyfRJkJaEe6tO8bOoJ4-CQ" x="-16" y="-19"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_WyfRJkJaEe6tO8bOoJ4-CQ" x="-13" y="-31"/>
       </children>
       <styles xsi:type="notation:FontStyle" xmi:id="_WyfRJ0JaEe6tO8bOoJ4-CQ" fontName="Segoe UI" fontHeight="6"/>
       <element href="TapiStreamingGnmi.uml#_aU9CcLzoEe2tPvK7TLwO7Q"/>
@@ -5575,7 +5575,7 @@
       </children>
       <children xsi:type="notation:DecorationNode" xmi:id="_WypCQkJaEe6tO8bOoJ4-CQ" type="Association_TargetMultiplicityLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_WypCQ0JaEe6tO8bOoJ4-CQ" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xsi:type="notation:Location" xmi:id="_WypCREJaEe6tO8bOoJ4-CQ" x="-15" y="-27"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_WypCREJaEe6tO8bOoJ4-CQ" x="-13" y="-24"/>
       </children>
       <styles xsi:type="notation:FontStyle" xmi:id="_WypCRUJaEe6tO8bOoJ4-CQ" fontName="Segoe UI" fontHeight="6"/>
       <element href="TapiStreamingGnmi.uml#_OOMkoLzrEe2tPvK7TLwO7Q"/>
@@ -5637,127 +5637,127 @@
       <element href="TapiStreamingGnmi.uml#_yH00ALzjEe2tPvK7TLwO7Q"/>
       <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_WypEvUJaEe6tO8bOoJ4-CQ" points="[990, -230, -643984, -643984]$[651, -150, -643984, -643984]"/>
       <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_WypEvkJaEe6tO8bOoJ4-CQ" id="(0.498220640569395,0.0)"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_WypEv0JaEe6tO8bOoJ4-CQ" id="(0.5524861878453039,1.0)"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_WypEv0JaEe6tO8bOoJ4-CQ" id="(0.4986149584487535,1.0)"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_olBFrVITEe6m_d6KGfEFwg" type="StereotypeCommentLink" source="_WyfRU0JaEe6tO8bOoJ4-CQ" target="_olBFqVITEe6m_d6KGfEFwg">
-      <styles xsi:type="notation:FontStyle" xmi:id="_olBFrlITEe6m_d6KGfEFwg"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_olBFslITEe6m_d6KGfEFwg" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_OhHbxGaAEe6bwd8NmC1HOg" type="StereotypeCommentLink" source="_WyfRU0JaEe6tO8bOoJ4-CQ" target="_OhHbwGaAEe6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_OhHbxWaAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_OhHbyWaAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_jUkBwLzoEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_olBFr1ITEe6m_d6KGfEFwg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_olBFsFITEe6m_d6KGfEFwg"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_olBFsVITEe6m_d6KGfEFwg"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_OhHbxmaAEe6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_OhHbx2aAEe6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_OhHbyGaAEe6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_olVOsVITEe6m_d6KGfEFwg" type="StereotypeCommentLink" source="_WypCVEJaEe6tO8bOoJ4-CQ" target="_olVOrVITEe6m_d6KGfEFwg">
-      <styles xsi:type="notation:FontStyle" xmi:id="_olVOslITEe6m_d6KGfEFwg"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_olVOtlITEe6m_d6KGfEFwg" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_OhWsZGaAEe6bwd8NmC1HOg" type="StereotypeCommentLink" source="_WypCVEJaEe6tO8bOoJ4-CQ" target="_OhWsYGaAEe6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_OhWsZWaAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_OhWsaWaAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreaming.uml#_X9ay8LqKEemx9sMHf8Tuig"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_olVOs1ITEe6m_d6KGfEFwg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_olVOtFITEe6m_d6KGfEFwg"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_olVOtVITEe6m_d6KGfEFwg"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_OhWsZmaAEe6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_OhWsZ2aAEe6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_OhWsaGaAEe6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_ole_p1ITEe6m_d6KGfEFwg" type="StereotypeCommentLink" source="_WypCfEJaEe6tO8bOoJ4-CQ" target="_ole_o1ITEe6m_d6KGfEFwg">
-      <styles xsi:type="notation:FontStyle" xmi:id="_ole_qFITEe6m_d6KGfEFwg"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_ole_rFITEe6m_d6KGfEFwg" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_OhpnRGaAEe6bwd8NmC1HOg" type="StereotypeCommentLink" source="_WypCfEJaEe6tO8bOoJ4-CQ" target="_OhpnQGaAEe6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_OhpnRWaAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_OhpnSWaAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_LyQ8cLzlEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_ole_qVITEe6m_d6KGfEFwg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_ole_qlITEe6m_d6KGfEFwg"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_ole_q1ITEe6m_d6KGfEFwg"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_OhpnRmaAEe6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_OhpnR2aAEe6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_OhpnSGaAEe6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_olql21ITEe6m_d6KGfEFwg" type="StereotypeCommentLink" source="_WypCvUJaEe6tO8bOoJ4-CQ" target="_olql11ITEe6m_d6KGfEFwg">
-      <styles xsi:type="notation:FontStyle" xmi:id="_olql3FITEe6m_d6KGfEFwg"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_olql4FITEe6m_d6KGfEFwg" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_OhzYT2aAEe6bwd8NmC1HOg" type="StereotypeCommentLink" source="_WypCvUJaEe6tO8bOoJ4-CQ" target="_OhzYS2aAEe6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_OhzYUGaAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_OhzYVGaAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_jAoQkLzREe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_olql3VITEe6m_d6KGfEFwg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_olql3lITEe6m_d6KGfEFwg"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_olql31ITEe6m_d6KGfEFwg"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_OhzYUWaAEe6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_OhzYUmaAEe6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_OhzYU2aAEe6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_ol1lFVITEe6m_d6KGfEFwg" type="StereotypeCommentLink" source="_WypCLkJaEe6tO8bOoJ4-CQ" target="_ol1lEVITEe6m_d6KGfEFwg">
-      <styles xsi:type="notation:FontStyle" xmi:id="_ol1lFlITEe6m_d6KGfEFwg"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_ol1lGlITEe6m_d6KGfEFwg" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_OiIIZ2aAEe6bwd8NmC1HOg" type="StereotypeCommentLink" source="_WypCLkJaEe6tO8bOoJ4-CQ" target="_OiIIY2aAEe6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_OiIIaGaAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_OiIIbGaAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_OOMkoLzrEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_ol1lF1ITEe6m_d6KGfEFwg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_ol1lGFITEe6m_d6KGfEFwg"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_ol1lGVITEe6m_d6KGfEFwg"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_OiIIaWaAEe6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_OiIIamaAEe6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_OiIIa2aAEe6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_ol1lJlITEe6m_d6KGfEFwg" type="StereotypeCommentLink" source="_WypEjUJaEe6tO8bOoJ4-CQ" target="_ol1lIlITEe6m_d6KGfEFwg">
-      <styles xsi:type="notation:FontStyle" xmi:id="_ol1lJ1ITEe6m_d6KGfEFwg"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_ol1lK1ITEe6m_d6KGfEFwg" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_OiIIeGaAEe6bwd8NmC1HOg" type="StereotypeCommentLink" source="_WypEjUJaEe6tO8bOoJ4-CQ" target="_OiIIdGaAEe6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_OiIIeWaAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_OiIIfWaAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_Q6Dt8LzrEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_ol1lKFITEe6m_d6KGfEFwg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_ol1lKVITEe6m_d6KGfEFwg"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_ol1lKlITEe6m_d6KGfEFwg"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_OiIIemaAEe6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_OiIIe2aAEe6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_OiIIfGaAEe6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_omH431ITEe6m_d6KGfEFwg" type="StereotypeCommentLink" source="_WypEGEJaEe6tO8bOoJ4-CQ" target="_omH421ITEe6m_d6KGfEFwg">
-      <styles xsi:type="notation:FontStyle" xmi:id="_omH44FITEe6m_d6KGfEFwg"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_omH45FITEe6m_d6KGfEFwg" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_OibqdmaAEe6bwd8NmC1HOg" type="StereotypeCommentLink" source="_WypEGEJaEe6tO8bOoJ4-CQ" target="_OibqcmaAEe6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_Oibqd2aAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_Oibqe2aAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_UjNPoLzPEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_omH44VITEe6m_d6KGfEFwg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_omH44lITEe6m_d6KGfEFwg"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_omH441ITEe6m_d6KGfEFwg"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_OibqeGaAEe6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_OibqeWaAEe6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_OibqemaAEe6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_omSQ51ITEe6m_d6KGfEFwg" type="StereotypeCommentLink" source="_WyfRNUJaEe6tO8bOoJ4-CQ" target="_omSQ41ITEe6m_d6KGfEFwg">
-      <styles xsi:type="notation:FontStyle" xmi:id="_omSQ6FITEe6m_d6KGfEFwg"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_omSQ7FITEe6m_d6KGfEFwg" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_OiulVGaAEe6bwd8NmC1HOg" type="StereotypeCommentLink" source="_WyfRNUJaEe6tO8bOoJ4-CQ" target="_OiulUGaAEe6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_OiulVWaAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_OiulWWaAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_CNum8LzsEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_omSQ6VITEe6m_d6KGfEFwg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_omSQ6lITEe6m_d6KGfEFwg"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_omSQ61ITEe6m_d6KGfEFwg"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_OiulVmaAEe6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_OiulV2aAEe6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_OiulWGaAEe6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_omSQ-FITEe6m_d6KGfEFwg" type="StereotypeCommentLink" source="_WypEq0JaEe6tO8bOoJ4-CQ" target="_omSQ9FITEe6m_d6KGfEFwg">
-      <styles xsi:type="notation:FontStyle" xmi:id="_omSQ-VITEe6m_d6KGfEFwg"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_omSQ_VITEe6m_d6KGfEFwg" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_OiulZWaAEe6bwd8NmC1HOg" type="StereotypeCommentLink" source="_WypEq0JaEe6tO8bOoJ4-CQ" target="_OiulYWaAEe6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_OiulZmaAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_OiulamaAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_yH00ALzjEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_omSQ-lITEe6m_d6KGfEFwg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_omSQ-1ITEe6m_d6KGfEFwg"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_omSQ_FITEe6m_d6KGfEFwg"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_OiulZ2aAEe6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_OiulaGaAEe6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_OiulaWaAEe6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_omcB71ITEe6m_d6KGfEFwg" type="StereotypeCommentLink" source="_WypEwEJaEe6tO8bOoJ4-CQ" target="_omcB61ITEe6m_d6KGfEFwg">
-      <styles xsi:type="notation:FontStyle" xmi:id="_omcB8FITEe6m_d6KGfEFwg"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_omcB9FITEe6m_d6KGfEFwg" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_Oi4WX2aAEe6bwd8NmC1HOg" type="StereotypeCommentLink" source="_WypEwEJaEe6tO8bOoJ4-CQ" target="_Oi4WW2aAEe6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_Oi4WYGaAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_Oi4WZGaAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_PLA5kLzoEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_omcB8VITEe6m_d6KGfEFwg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_omcB8lITEe6m_d6KGfEFwg"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_omcB81ITEe6m_d6KGfEFwg"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_Oi4WYWaAEe6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_Oi4WYmaAEe6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_Oi4WY2aAEe6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_ommaMFITEe6m_d6KGfEFwg" type="StereotypeCommentLink" source="_WyfREEJaEe6tO8bOoJ4-CQ" target="_ommaLFITEe6m_d6KGfEFwg">
-      <styles xsi:type="notation:FontStyle" xmi:id="_ommaMVITEe6m_d6KGfEFwg"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_ommaNVITEe6m_d6KGfEFwg" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_OjL4VGaAEe6bwd8NmC1HOg" type="StereotypeCommentLink" source="_WyfREEJaEe6tO8bOoJ4-CQ" target="_OjL4UGaAEe6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_OjL4VWaAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_OjL4WWaAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_aU9CcLzoEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_ommaMlITEe6m_d6KGfEFwg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_ommaM1ITEe6m_d6KGfEFwg"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_ommaNFITEe6m_d6KGfEFwg"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_OjL4VmaAEe6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_OjL4V2aAEe6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_OjL4WGaAEe6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_ommaQVITEe6m_d6KGfEFwg" type="StereotypeCommentLink" source="_WypCEEJaEe6tO8bOoJ4-CQ" target="_ommaPVITEe6m_d6KGfEFwg">
-      <styles xsi:type="notation:FontStyle" xmi:id="_ommaQlITEe6m_d6KGfEFwg"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_ommaRlITEe6m_d6KGfEFwg" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_OjNGe2aAEe6bwd8NmC1HOg" type="StereotypeCommentLink" source="_WypCEEJaEe6tO8bOoJ4-CQ" target="_OjNGd2aAEe6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_OjNGfGaAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_OjNGgGaAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_R_-CkLzqEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_ommaQ1ITEe6m_d6KGfEFwg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_ommaRFITEe6m_d6KGfEFwg"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_ommaRVITEe6m_d6KGfEFwg"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_OjNGfWaAEe6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_OjNGfmaAEe6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_OjNGf2aAEe6bwd8NmC1HOg"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_jtP3UEJaEe6tO8bOoJ4-CQ" type="PapyrusUMLClassDiagram" name="BasicMeasurementReportingStructure" measurementUnit="Pixel">
@@ -5772,7 +5772,7 @@
         <element href="TapiStreamingGnmi.uml#_CfYvcN2UEeyisriSvKT5Lw"/>
       </children>
       <element href="TapiStreamingGnmi.uml#_CfYvcN2UEeyisriSvKT5Lw"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_pN18p0JbEe6tO8bOoJ4-CQ" x="-480" y="-220" width="141" height="21"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_pN18p0JbEe6tO8bOoJ4-CQ" x="-620" y="-220" width="161" height="21"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_pN18qEJbEe6tO8bOoJ4-CQ" type="Comment_Shape" fontName="Segoe UI" fontHeight="6" fillColor="12560536">
       <eAnnotations xmi:id="_pN18qUJbEe6tO8bOoJ4-CQ" source="PapyrusCSSForceValue">
@@ -5782,7 +5782,7 @@
       </eAnnotations>
       <children xsi:type="notation:DecorationNode" xmi:id="_pN18rUJbEe6tO8bOoJ4-CQ" type="Comment_BodyLabel"/>
       <element href="TapiStreamingGnmi.uml#_dWerALzuEe2tPvK7TLwO7Q"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_pN18rkJbEe6tO8bOoJ4-CQ" x="-480" y="-340" width="141" height="8"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_pN18rkJbEe6tO8bOoJ4-CQ" x="-620" y="-340" width="161" height="8"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_1tyPIUJbEe6tO8bOoJ4-CQ" type="Comment_Shape" fontColor="128" fontName="Segoe UI" fontHeight="6">
       <eAnnotations xmi:id="_7ChfMEJbEe6tO8bOoJ4-CQ" source="PapyrusCSSForceValue">
@@ -5793,7 +5793,7 @@
       </eAnnotations>
       <children xsi:type="notation:DecorationNode" xmi:id="_1tyPI0JbEe6tO8bOoJ4-CQ" type="Comment_BodyLabel"/>
       <element href="TapiStreamingGnmi.uml#_1tyPIEJbEe6tO8bOoJ4-CQ"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_1tyPIkJbEe6tO8bOoJ4-CQ" x="-480" y="180" width="122" height="21"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_1tyPIkJbEe6tO8bOoJ4-CQ" x="-620" y="180" width="162" height="21"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_FwTQgUJcEe6tO8bOoJ4-CQ" type="Comment_Shape" fontColor="16711680" fontName="Segoe UI" fontHeight="6">
       <eAnnotations xmi:id="_LPigYEJcEe6tO8bOoJ4-CQ" source="PapyrusCSSForceValue">
@@ -5803,7 +5803,7 @@
       </eAnnotations>
       <children xsi:type="notation:DecorationNode" xmi:id="_FwTQg0JcEe6tO8bOoJ4-CQ" type="Comment_BodyLabel"/>
       <element href="TapiStreamingGnmi.uml#_FwTQgEJcEe6tO8bOoJ4-CQ"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_FwTQgkJcEe6tO8bOoJ4-CQ" x="-480" y="220" width="121" height="21"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_FwTQgkJcEe6tO8bOoJ4-CQ" x="-620" y="220" width="161" height="21"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_QnzlkUJcEe6tO8bOoJ4-CQ" type="Comment_Shape" fontColor="255" fontName="Segoe UI" fontHeight="6">
       <eAnnotations xmi:id="_WMxqAEJcEe6tO8bOoJ4-CQ" source="PapyrusCSSForceValue">
@@ -5813,7 +5813,7 @@
       </eAnnotations>
       <children xsi:type="notation:DecorationNode" xmi:id="_Qnzlk0JcEe6tO8bOoJ4-CQ" type="Comment_BodyLabel"/>
       <element href="TapiStreamingGnmi.uml#_QnzlkEJcEe6tO8bOoJ4-CQ"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_QnzlkkJcEe6tO8bOoJ4-CQ" x="-480" y="260" width="121" height="21"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_QnzlkkJcEe6tO8bOoJ4-CQ" x="-620" y="260" width="161" height="21"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_e1WCUUJcEe6tO8bOoJ4-CQ" type="Comment_Shape" fontColor="32768" fontName="Segoe UI" fontHeight="6">
       <eAnnotations xmi:id="_i-EyQEJcEe6tO8bOoJ4-CQ" source="PapyrusCSSForceValue">
@@ -5823,7 +5823,7 @@
       </eAnnotations>
       <children xsi:type="notation:DecorationNode" xmi:id="_e1WCU0JcEe6tO8bOoJ4-CQ" type="Comment_BodyLabel"/>
       <element href="TapiStreamingGnmi.uml#_e1WCUEJcEe6tO8bOoJ4-CQ"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_e1WCUkJcEe6tO8bOoJ4-CQ" x="-480" y="300" width="121" height="21"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_e1WCUkJcEe6tO8bOoJ4-CQ" x="-620" y="300" width="161" height="21"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_YTTVIFIUEe6m_d6KGfEFwg" type="Class_Shape" fontName="Segoe UI" fontHeight="6" fillColor="12621752">
       <eAnnotations xmi:id="_YTTVIVIUEe6m_d6KGfEFwg" source="PapyrusCSSForceValue">
@@ -5892,7 +5892,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="_YTTValIUEe6m_d6KGfEFwg"/>
       </children>
       <element href="TapiStreamingGnmi.uml#_Z81vULzmEe2tPvK7TLwO7Q"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_YTTVlFIUEe6m_d6KGfEFwg" x="-320" y="-220" width="321" height="60"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_YTTVlFIUEe6m_d6KGfEFwg" x="-400" y="-220" width="481" height="60"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_YTVKblIUEe6m_d6KGfEFwg" type="Class_Shape" fontName="Segoe UI" fontHeight="6" fillColor="12621752" lineColor="0">
       <eAnnotations xmi:id="_YTVKb1IUEe6m_d6KGfEFwg" source="PapyrusCSSForceValue">
@@ -5961,7 +5961,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="_YTVKuFIUEe6m_d6KGfEFwg"/>
       </children>
       <element href="TapiStreamingGnmi.uml#_Gu2rwOi9Ee2WXqIYPh2wfQ"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_YTVK4lIUEe6m_d6KGfEFwg" x="-320" y="-100" width="320" height="60"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_YTVK4lIUEe6m_d6KGfEFwg" x="-400" y="-100" width="480" height="60"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_YTVK41IUEe6m_d6KGfEFwg" type="Class_Shape" fontName="Segoe UI" fontHeight="6" fillColor="12621752">
       <eAnnotations xmi:id="_YTVK5FIUEe6m_d6KGfEFwg" source="PapyrusCSSForceValue">
@@ -6425,7 +6425,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="_YTVNC1IUEe6m_d6KGfEFwg"/>
       </children>
       <element href="TapiStreamingGnmi.uml#_KRgyMFIQEe6m_d6KGfEFwg"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_YTVNNVIUEe6m_d6KGfEFwg" x="-280" y="160" width="381" height="201"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_YTVNNVIUEe6m_d6KGfEFwg" x="-360" y="160" width="541" height="201"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_YTVNNlIUEe6m_d6KGfEFwg" type="Class_Shape" fontName="Segoe UI" fontHeight="6" fillColor="12621752">
       <eAnnotations xmi:id="_YTVNN1IUEe6m_d6KGfEFwg" source="PapyrusCSSForceValue">
@@ -6500,7 +6500,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="_YTVNgFIUEe6m_d6KGfEFwg"/>
       </children>
       <element href="TapiStreamingGnmi.uml#_Aow5sKFgEe2n-fmfRwdlPg"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_YTVNqlIUEe6m_d6KGfEFwg" x="-320" y="20" width="321" height="60"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_YTVNqlIUEe6m_d6KGfEFwg" x="-400" y="20" width="481" height="60"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_YTVNyVIUEe6m_d6KGfEFwg" type="Class_Shape" fontName="Segoe UI" fontHeight="6" fillColor="12560536">
       <eAnnotations xmi:id="_YTVNylIUEe6m_d6KGfEFwg" source="PapyrusCSSForceValue">
@@ -6531,7 +6531,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="_YTVN31IUEe6m_d6KGfEFwg"/>
       </children>
       <element href="TapiStreamingGnmi.uml#_LyQ8cLzlEe2tPvK7TLwO7Q"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_YTVOCVIUEe6m_d6KGfEFwg" x="-300" y="-340" width="281" height="60"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_YTVOCVIUEe6m_d6KGfEFwg" x="-400" y="-340" width="481" height="60"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_YTVOClIUEe6m_d6KGfEFwg" type="Class_Shape" fontName="Segoe UI" fontHeight="6" fillColor="12621752">
       <eAnnotations xmi:id="_YTVOC1IUEe6m_d6KGfEFwg" source="PapyrusCSSForceValue">
@@ -6793,95 +6793,95 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="_YTVPI1IUEe6m_d6KGfEFwg"/>
       </children>
       <element href="TapiStreamingGnmi.uml#_406Q8KFhEe2n-fmfRwdlPg"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_YTVPTVIUEe6m_d6KGfEFwg" x="-340" y="420" width="381" height="221"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_YTVPTVIUEe6m_d6KGfEFwg" x="-420" y="420" width="541" height="221"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_ip3b4FecEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_ip3b4VecEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_ip4C8FecEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_lfQLe2aAEe6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_lfQLfGaAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_lfQLfmaAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_Z81vULzmEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_ip3b4lecEe6mE7NoRC7Zaw" x="-120" y="-220"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_lfQLfWaAEe6bwd8NmC1HOg" x="-120" y="-220"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_iqBM4FecEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_iqBM4VecEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_iqBM41ecEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_lfZVhWaAEe6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_lfZVhmaAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_lfZViGaAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_LqfOkLznEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_iqBM4lecEe6mE7NoRC7Zaw" x="-120" y="-320"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_lfZVh2aAEe6bwd8NmC1HOg" x="-120" y="-320"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_iqMMAFecEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_iqMMAVecEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_iqMMA1ecEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_lfjGcmaAEe6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_lfjGc2aAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_lfjGdWaAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_Gu2rwOi9Ee2WXqIYPh2wfQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_iqMMAlecEe6mE7NoRC7Zaw" x="-120" y="-100"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_lfjGdGaAEe6bwd8NmC1HOg" x="-120" y="-100"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_iqV9AFecEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_iqV9AVecEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_iqV9A1ecEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_lfwh4WaAEe6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_lfwh4maAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_lfwh5GaAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_eQ-SQOi9Ee2WXqIYPh2wfQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_iqV9AlecEe6mE7NoRC7Zaw" x="-120" y="-200"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_lfwh42aAEe6bwd8NmC1HOg" x="-120" y="-200"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_iqef4FecEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_iqef4VecEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_iqfG8FecEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_lf6522aAEe6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_lf653GaAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_lf653maAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_KRgyMFIQEe6m_d6KGfEFwg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_iqef4lecEe6mE7NoRC7Zaw" x="-80" y="160"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_lf653WaAEe6bwd8NmC1HOg" x="-80" y="160"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_irGyAFecEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_irGyAVecEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_irHZEFecEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_lgndYGaAEe6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_lgndYWaAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_lgndY2aAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_Aow5sKFgEe2n-fmfRwdlPg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_irGyAlecEe6mE7NoRC7Zaw" x="-120" y="20"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_lgndYmaAEe6bwd8NmC1HOg" x="-120" y="20"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_irQjAFecEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_irQjAVecEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_irQjA1ecEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_lgtkFmaAEe6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_lgtkF2aAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_lgtkGWaAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#__d9xQEODEe6bIJjw8ZnZGQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_irQjAlecEe6mE7NoRC7Zaw" x="-120" y="-80"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_lgtkGGaAEe6bwd8NmC1HOg" x="-120" y="-80"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_irUNYFecEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_irUNYVecEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_irUNY1ecEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_lgtkJ2aAEe6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_lgtkKGaAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_lgtkKmaAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_S1iBsFIQEe6m_d6KGfEFwg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_irUNYlecEe6mE7NoRC7Zaw" x="-120" y="-80"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_lgtkKWaAEe6bwd8NmC1HOg" x="-120" y="-80"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_irfMgFecEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_irfMgVecEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_irfMg1ecEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_lhAe8GaAEe6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_lhAe8WaAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_lhAe82aAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_LyQ8cLzlEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_irfMglecEe6mE7NoRC7Zaw" x="-100" y="-340"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_lhAe8maAEe6bwd8NmC1HOg" x="-100" y="-340"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_irlTIFecEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_irlTIVecEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_irl6MFecEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_lhAfHWaAEe6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_lhAfHmaAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_lhAfIGaAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_zx-10EOEEe6bIJjw8ZnZGQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_irlTIlecEe6mE7NoRC7Zaw" x="-100" y="-440"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_lhAfH2aAEe6bwd8NmC1HOg" x="-100" y="-440"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_irwSQFecEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_irwSQVecEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_irwSQ1ecEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_lhVPEGaAEe6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_lhVPEWaAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_lhVPE2aAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_406Q8KFhEe2n-fmfRwdlPg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_irwSQlecEe6mE7NoRC7Zaw" x="-140" y="420"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_lhVPEmaAEe6bwd8NmC1HOg" x="-140" y="420"/>
     </children>
     <styles xsi:type="notation:StringValueStyle" xmi:id="_jtP3UUJaEe6tO8bOoJ4-CQ" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xsi:type="notation:DiagramStyle" xmi:id="_jtP3UkJaEe6tO8bOoJ4-CQ"/>
@@ -6913,11 +6913,11 @@
       </children>
       <children xsi:type="notation:DecorationNode" xmi:id="_YTVKYVIUEe6m_d6KGfEFwg" type="Association_SourceMultiplicityLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_YTVKYlIUEe6m_d6KGfEFwg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xsi:type="notation:Location" xmi:id="_YTVKY1IUEe6m_d6KGfEFwg" x="5" y="37"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_YTVKY1IUEe6m_d6KGfEFwg" x="7" y="15"/>
       </children>
       <children xsi:type="notation:DecorationNode" xmi:id="_YTVKZFIUEe6m_d6KGfEFwg" type="Association_TargetMultiplicityLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_YTVKZVIUEe6m_d6KGfEFwg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xsi:type="notation:Location" xmi:id="_YTVKZlIUEe6m_d6KGfEFwg" x="-15" y="33"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_YTVKZlIUEe6m_d6KGfEFwg" x="-13" y="-31"/>
       </children>
       <styles xsi:type="notation:FontStyle" xmi:id="_YTVKZ1IUEe6m_d6KGfEFwg" fontName="Segoe UI" fontHeight="6"/>
       <element href="TapiStreamingGnmi.uml#_LqfOkLznEe2tPvK7TLwO7Q"/>
@@ -6949,17 +6949,17 @@
       </children>
       <children xsi:type="notation:DecorationNode" xmi:id="_YTVNvFIUEe6m_d6KGfEFwg" type="Association_SourceMultiplicityLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_YTVNvVIUEe6m_d6KGfEFwg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xsi:type="notation:Location" xmi:id="_YTVNvlIUEe6m_d6KGfEFwg" x="5" y="13"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_YTVNvlIUEe6m_d6KGfEFwg" x="7" y="29"/>
       </children>
       <children xsi:type="notation:DecorationNode" xmi:id="_YTVNv1IUEe6m_d6KGfEFwg" type="Association_TargetMultiplicityLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_YTVNwFIUEe6m_d6KGfEFwg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xsi:type="notation:Location" xmi:id="_YTVNwVIUEe6m_d6KGfEFwg" x="-15" y="-27"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_YTVNwVIUEe6m_d6KGfEFwg" x="-13" y="-25"/>
       </children>
       <styles xsi:type="notation:FontStyle" xmi:id="_YTVNwlIUEe6m_d6KGfEFwg" fontName="Segoe UI" fontHeight="6"/>
       <element href="TapiStreamingGnmi.uml#__d9xQEODEe6bIJjw8ZnZGQ"/>
       <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_YTVNxlIUEe6m_d6KGfEFwg" points="[115, 155, -643984, -643984]$[95, 255, -643984, -643984]"/>
       <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_YTVNx1IUEe6m_d6KGfEFwg" id="(0.06230529595015576,1.0)"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_YTVNyFIUEe6m_d6KGfEFwg" id="(0.10498687664041995,0.0)"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_YTVNyFIUEe6m_d6KGfEFwg" id="(0.07393715341959335,0.0)"/>
     </edges>
     <edges xsi:type="notation:Connector" xmi:id="_YTVPTlIUEe6m_d6KGfEFwg" type="Association_Edge" source="_YTVKblIUEe6m_d6KGfEFwg" target="_YTVNNlIUEe6m_d6KGfEFwg">
       <eAnnotations xmi:id="_YTVPT1IUEe6m_d6KGfEFwg" source="PapyrusCSSForceValue">
@@ -6985,11 +6985,11 @@
       </children>
       <children xsi:type="notation:DecorationNode" xmi:id="_YTVPX1IUEe6m_d6KGfEFwg" type="Association_SourceMultiplicityLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_YTVPYFIUEe6m_d6KGfEFwg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xsi:type="notation:Location" xmi:id="_YTVPYVIUEe6m_d6KGfEFwg" x="9" y="20"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_YTVPYVIUEe6m_d6KGfEFwg" x="7" y="15"/>
       </children>
       <children xsi:type="notation:DecorationNode" xmi:id="_YTVPYlIUEe6m_d6KGfEFwg" type="Association_TargetMultiplicityLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_YTVPY1IUEe6m_d6KGfEFwg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xsi:type="notation:Location" xmi:id="_YTVPZFIUEe6m_d6KGfEFwg" x="-10" y="-20"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_YTVPZFIUEe6m_d6KGfEFwg" x="-13" y="-31"/>
       </children>
       <styles xsi:type="notation:FontStyle" xmi:id="_YTVPZVIUEe6m_d6KGfEFwg" fontName="Segoe UI" fontHeight="6"/>
       <element href="TapiStreamingGnmi.uml#_eQ-SQOi9Ee2WXqIYPh2wfQ"/>
@@ -7021,16 +7021,16 @@
       </children>
       <children xsi:type="notation:DecorationNode" xmi:id="_YTVPfVIUEe6m_d6KGfEFwg" type="Association_SourceMultiplicityLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_YTVPflIUEe6m_d6KGfEFwg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xsi:type="notation:Location" xmi:id="_YTVPf1IUEe6m_d6KGfEFwg" x="3" y="19"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_YTVPf1IUEe6m_d6KGfEFwg" x="7" y="29"/>
       </children>
       <children xsi:type="notation:DecorationNode" xmi:id="_YTVPgFIUEe6m_d6KGfEFwg" type="Association_TargetMultiplicityLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_YTVPgVIUEe6m_d6KGfEFwg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xsi:type="notation:Location" xmi:id="_YTVPglIUEe6m_d6KGfEFwg" x="-5" y="-19"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_YTVPglIUEe6m_d6KGfEFwg" x="-13" y="-25"/>
       </children>
       <styles xsi:type="notation:FontStyle" xmi:id="_YTVPg1IUEe6m_d6KGfEFwg" fontName="Segoe UI" fontHeight="6"/>
       <element href="TapiStreamingGnmi.uml#_S1iBsFIQEe6m_d6KGfEFwg"/>
       <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_YTVPh1IUEe6m_d6KGfEFwg" points="[75, 155, -643984, -643984]$[15, 175, -643984, -643984]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_YTVPiFIUEe6m_d6KGfEFwg" id="(0.5607476635514018,1.0)"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_YTVPiFIUEe6m_d6KGfEFwg" id="(0.498960498960499,1.0)"/>
       <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_YTVPiVIUEe6m_d6KGfEFwg" id="(0.3674540682414698,0.0)"/>
     </edges>
     <edges xsi:type="notation:Connector" xmi:id="_YTVPilIUEe6m_d6KGfEFwg" type="Association_Edge" source="_YTVNyVIUEe6m_d6KGfEFwg" target="_YTTVIFIUEe6m_d6KGfEFwg">
@@ -7057,11 +7057,11 @@
       </children>
       <children xsi:type="notation:DecorationNode" xmi:id="_YTVPm1IUEe6m_d6KGfEFwg" type="Association_SourceMultiplicityLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_YTVPnFIUEe6m_d6KGfEFwg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xsi:type="notation:Location" xmi:id="_YTVPnVIUEe6m_d6KGfEFwg" x="6" y="20"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_YTVPnVIUEe6m_d6KGfEFwg" x="7" y="15"/>
       </children>
       <children xsi:type="notation:DecorationNode" xmi:id="_YTVPnlIUEe6m_d6KGfEFwg" type="Association_TargetMultiplicityLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_YTVPn1IUEe6m_d6KGfEFwg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xsi:type="notation:Location" xmi:id="_YTVPoFIUEe6m_d6KGfEFwg" x="-6" y="-20"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_YTVPoFIUEe6m_d6KGfEFwg" x="-13" y="-27"/>
       </children>
       <styles xsi:type="notation:FontStyle" xmi:id="_YTVPoVIUEe6m_d6KGfEFwg" fontName="Segoe UI" fontHeight="6"/>
       <element href="TapiStreamingGnmi.uml#_zx-10EOEEe6bIJjw8ZnZGQ"/>
@@ -7069,115 +7069,115 @@
       <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_YTVPplIUEe6m_d6KGfEFwg" id="(0.4979253112033195,1.0)"/>
       <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_YTVPp1IUEe6m_d6KGfEFwg" id="(0.4984423676012461,0.0)"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_ip4C8VecEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_YTTVIFIUEe6m_d6KGfEFwg" target="_ip3b4FecEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_ip4C8lecEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_ip4C9lecEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_lfQLf2aAEe6bwd8NmC1HOg" type="StereotypeCommentLink" source="_YTTVIFIUEe6m_d6KGfEFwg" target="_lfQLe2aAEe6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_lfQLgGaAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_lfQLhGaAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_Z81vULzmEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_ip4C81ecEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_ip4C9FecEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_ip4C9VecEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_lfQLgWaAEe6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_lfQLgmaAEe6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_lfQLg2aAEe6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_iqBM5FecEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_YTVKUFIUEe6m_d6KGfEFwg" target="_iqBM4FecEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_iqBM5VecEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_iqBM6VecEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_lfZViWaAEe6bwd8NmC1HOg" type="StereotypeCommentLink" source="_YTVKUFIUEe6m_d6KGfEFwg" target="_lfZVhWaAEe6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_lfZVimaAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_lfZVjmaAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_LqfOkLznEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_iqBM5lecEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_iqBM51ecEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_iqBM6FecEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_lfZVi2aAEe6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_lfZVjGaAEe6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_lfZVjWaAEe6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_iqMMBFecEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_YTVKblIUEe6m_d6KGfEFwg" target="_iqMMAFecEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_iqMMBVecEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_iqMMCVecEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_lfjGdmaAEe6bwd8NmC1HOg" type="StereotypeCommentLink" source="_YTVKblIUEe6m_d6KGfEFwg" target="_lfjGcmaAEe6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_lfjGd2aAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_lfjGe2aAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_Gu2rwOi9Ee2WXqIYPh2wfQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_iqMMBlecEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_iqMMB1ecEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_iqMMCFecEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_lfjGeGaAEe6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_lfjGeWaAEe6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_lfjGemaAEe6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_iqWkEFecEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_YTVPTlIUEe6m_d6KGfEFwg" target="_iqV9AFecEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_iqWkEVecEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_iqWkFVecEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_lfwh5WaAEe6bwd8NmC1HOg" type="StereotypeCommentLink" source="_YTVPTlIUEe6m_d6KGfEFwg" target="_lfwh4WaAEe6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_lfwh5maAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_lfwh6maAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_eQ-SQOi9Ee2WXqIYPh2wfQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_iqWkElecEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_iqWkE1ecEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_iqWkFFecEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_lfwh52aAEe6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_lfwh6GaAEe6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_lfwh6WaAEe6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_iqfG8VecEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_YTVK41IUEe6m_d6KGfEFwg" target="_iqef4FecEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_iqfG8lecEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_iqfG9lecEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_lf6532aAEe6bwd8NmC1HOg" type="StereotypeCommentLink" source="_YTVK41IUEe6m_d6KGfEFwg" target="_lf6522aAEe6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_lf654GaAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_lf655GaAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_KRgyMFIQEe6m_d6KGfEFwg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_iqfG81ecEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_iqfG9FecEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_iqfG9VecEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_lf654WaAEe6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_lf654maAEe6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_lf6542aAEe6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_irHZEVecEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_YTVNNlIUEe6m_d6KGfEFwg" target="_irGyAFecEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_irHZElecEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_irHZFlecEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_lgndZGaAEe6bwd8NmC1HOg" type="StereotypeCommentLink" source="_YTVNNlIUEe6m_d6KGfEFwg" target="_lgndYGaAEe6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_lgndZWaAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_lgndaWaAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_Aow5sKFgEe2n-fmfRwdlPg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_irHZE1ecEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_irHZFFecEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_irHZFVecEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_lgndZmaAEe6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_lgndZ2aAEe6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_lgndaGaAEe6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_irQjBFecEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_YTVNq1IUEe6m_d6KGfEFwg" target="_irQjAFecEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_irQjBVecEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_irQjCVecEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_lgtkGmaAEe6bwd8NmC1HOg" type="StereotypeCommentLink" source="_YTVNq1IUEe6m_d6KGfEFwg" target="_lgtkFmaAEe6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_lgtkG2aAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_lgtkH2aAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#__d9xQEODEe6bIJjw8ZnZGQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_irQjBlecEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_irQjB1ecEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_irQjCFecEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_lgtkHGaAEe6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_lgtkHWaAEe6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_lgtkHmaAEe6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_irUNZFecEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_YTVPbFIUEe6m_d6KGfEFwg" target="_irUNYFecEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_irUNZVecEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_irUNaVecEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_lgtkK2aAEe6bwd8NmC1HOg" type="StereotypeCommentLink" source="_YTVPbFIUEe6m_d6KGfEFwg" target="_lgtkJ2aAEe6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_lgtkLGaAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_lgtkMGaAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_S1iBsFIQEe6m_d6KGfEFwg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_irUNZlecEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_irUNZ1ecEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_irUNaFecEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_lgtkLWaAEe6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_lgtkLmaAEe6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_lgtkL2aAEe6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_irfMhFecEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_YTVNyVIUEe6m_d6KGfEFwg" target="_irfMgFecEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_irfMhVecEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_irfMiVecEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_lhAe9GaAEe6bwd8NmC1HOg" type="StereotypeCommentLink" source="_YTVNyVIUEe6m_d6KGfEFwg" target="_lhAe8GaAEe6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_lhAe9WaAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_lhAe-WaAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_LyQ8cLzlEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_irfMhlecEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_irfMh1ecEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_irfMiFecEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_lhAe9maAEe6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_lhAe92aAEe6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_lhAe-GaAEe6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_irl6MVecEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_YTVPilIUEe6m_d6KGfEFwg" target="_irlTIFecEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_irl6MlecEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_irl6NlecEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_lhAfIWaAEe6bwd8NmC1HOg" type="StereotypeCommentLink" source="_YTVPilIUEe6m_d6KGfEFwg" target="_lhAfHWaAEe6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_lhAfImaAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_lhAfJmaAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_zx-10EOEEe6bIJjw8ZnZGQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_irl6M1ecEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_irl6NFecEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_irl6NVecEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_lhAfI2aAEe6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_lhAfJGaAEe6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_lhAfJWaAEe6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_irwSRFecEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_YTVOClIUEe6m_d6KGfEFwg" target="_irwSQFecEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_irwSRVecEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_irwSSVecEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_lhVPFGaAEe6bwd8NmC1HOg" type="StereotypeCommentLink" source="_YTVOClIUEe6m_d6KGfEFwg" target="_lhVPEGaAEe6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_lhVPFWaAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_lhVPGWaAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_406Q8KFhEe2n-fmfRwdlPg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_irwSRlecEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_irwSR1ecEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_irwSSFecEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_lhVPFmaAEe6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_lhVPF2aAEe6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_lhVPGGaAEe6bwd8NmC1HOg"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_DJT1kEJbEe6tO8bOoJ4-CQ" type="PapyrusUMLClassDiagram" name="MultipleMeasurementReportingStructure" measurementUnit="Pixel">
@@ -7643,7 +7643,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="_D2VuaFIVEe6m_d6KGfEFwg"/>
       </children>
       <element href="TapiStreamingGnmi.uml#_KRgyMFIQEe6m_d6KGfEFwg"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_D2VuklIVEe6m_d6KGfEFwg" x="-20" y="100" width="381" height="201"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_D2VuklIVEe6m_d6KGfEFwg" x="-100" y="100" width="541" height="201"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_D2Vuk1IVEe6m_d6KGfEFwg" type="Class_Shape" fontName="Segoe UI" fontHeight="6" fillColor="12621752">
       <eAnnotations xmi:id="_D2VulFIVEe6m_d6KGfEFwg" source="PapyrusCSSForceValue">
@@ -7762,7 +7762,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="_D2Vu4VIVEe6m_d6KGfEFwg"/>
       </children>
       <element href="TapiStreamingGnmi.uml#_FCwpUKYBEe2n-fmfRwdlPg"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_D2VvC1IVEe6m_d6KGfEFwg" x="500" y="100" width="301" height="61"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_D2VvC1IVEe6m_d6KGfEFwg" x="720" y="100" width="401" height="81"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_D2VvZlIVEe6m_d6KGfEFwg" type="Class_Shape" fontName="Segoe UI" fontHeight="6" fillColor="12621752">
       <eAnnotations xmi:id="_D2VvZ1IVEe6m_d6KGfEFwg" source="PapyrusCSSForceValue">
@@ -7837,7 +7837,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="_D2VvsFIVEe6m_d6KGfEFwg"/>
       </children>
       <element href="TapiStreamingGnmi.uml#_Aow5sKFgEe2n-fmfRwdlPg"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_D2Vv2lIVEe6m_d6KGfEFwg" x="-60" y="-40" width="321" height="60"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_D2Vv2lIVEe6m_d6KGfEFwg" x="-140" y="-40" width="481" height="60"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_D2VwF1IVEe6m_d6KGfEFwg" type="Class_Shape" fontName="Segoe UI" fontHeight="6" fillColor="12621752">
       <eAnnotations xmi:id="_D2VwGFIVEe6m_d6KGfEFwg" source="PapyrusCSSForceValue">
@@ -8100,79 +8100,133 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="_D2VxMFIVEe6m_d6KGfEFwg"/>
       </children>
       <element href="TapiStreamingGnmi.uml#_406Q8KFhEe2n-fmfRwdlPg"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_D2VxWlIVEe6m_d6KGfEFwg" x="-80" y="360" width="381" height="221"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_D2VxWlIVEe6m_d6KGfEFwg" x="-160" y="360" width="541" height="221"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_4HFycFecEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_4HFycVecEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_4HFyc1ecEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_9uyRm2aAEe6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_9uyRnGaAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_9uyRnmaAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_KRgyMFIQEe6m_d6KGfEFwg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4HFyclecEe6mE7NoRC7Zaw" x="180" y="100"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_9uyRnWaAEe6bwd8NmC1HOg" x="180" y="100"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_4HyWAFecEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_4HyWAVecEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_4HyWA1ecEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_9vteoGaAEe6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_9vteoWaAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_9vteo2aAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_FCwpUKYBEe2n-fmfRwdlPg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4HyWAlecEe6mE7NoRC7Zaw" x="700" y="100"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_9vteomaAEe6bwd8NmC1HOg" x="700" y="100"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_4H8uEFecEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_4H8uEVecEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_4H8uE1ecEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_9v6S8GaAEe6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_9v6S8WaAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_9v66AGaAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_ZhiA0EOEEe6bIJjw8ZnZGQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4H8uElecEe6mE7NoRC7Zaw" x="700"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_9v6S8maAEe6bwd8NmC1HOg" x="700"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_4IAYcFecEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_4IAYcVecEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_4IAYc1ecEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_9v_ygGaAEe6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_9v_ygWaAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_9v_yg2aAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_VET7gFISEe6m_d6KGfEFwg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4IAYclecEe6mE7NoRC7Zaw" x="700"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_9v_ygmaAEe6bwd8NmC1HOg" x="700"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_4ILXkFecEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_4ILXkVecEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_4ILXk1ecEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_9wKKl2aAEe6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_9wKKmGaAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_9wKKmmaAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_Aow5sKFgEe2n-fmfRwdlPg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4ILXklecEe6mE7NoRC7Zaw" x="140" y="-40"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_9wKKmWaAEe6bwd8NmC1HOg" x="140" y="-40"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_4IVIkFecEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_4IVIkVecEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_4IVIk1ecEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_9wVw5WaAEe6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_9wVw5maAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_9wVw6GaAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_S1iBsFIQEe6m_d6KGfEFwg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4IVIklecEe6mE7NoRC7Zaw" x="140" y="-140"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_9wVw52aAEe6bwd8NmC1HOg" x="140" y="-140"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_4IYy8FecEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_4IYy8VecEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_4IYy81ecEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_9wfhw2aAEe6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_9wfhxGaAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_9wfhxmaAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_SyXM4KYBEe2n-fmfRwdlPg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4IYy8lecEe6mE7NoRC7Zaw" x="140" y="-140"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_9wfhxWaAEe6bwd8NmC1HOg" x="140" y="-140"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_4IdEYFecEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_4IdEYVecEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_4IdEY1ecEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_9wfh1GaAEe6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_9wfh1WaAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_9wfh12aAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#__d9xQEODEe6bIJjw8ZnZGQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4IdEYlecEe6mE7NoRC7Zaw" x="140" y="-140"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_9wfh1maAEe6bwd8NmC1HOg" x="140" y="-140"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_4Irt4FecEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_4Irt4VecEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_4Irt41ecEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_9wyct2aAEe6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_9wycuGaAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_9wycumaAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_406Q8KFhEe2n-fmfRwdlPg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_4Irt4lecEe6mE7NoRC7Zaw" x="120" y="360"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_9wycuWaAEe6bwd8NmC1HOg" x="120" y="360"/>
+    </children>
+    <children xsi:type="notation:Shape" xmi:id="_cG7UsGaBEe6bwd8NmC1HOg" type="Comment_Shape" fontName="Segoe UI" fontHeight="6" fillColor="12621752">
+      <eAnnotations xmi:id="_cG7UsWaBEe6bwd8NmC1HOg" source="PapyrusCSSForceValue">
+        <details xmi:id="_cG7UsmaBEe6bwd8NmC1HOg" key="bold" value="true"/>
+        <details xmi:id="_cG7Us2aBEe6bwd8NmC1HOg" key="italic" value="true"/>
+        <details xmi:id="_cG7UtGaBEe6bwd8NmC1HOg" key="fontColor" value="true"/>
+        <details xmi:id="_cG7UtWaBEe6bwd8NmC1HOg" key="fontHeight" value="true"/>
+      </eAnnotations>
+      <children xsi:type="notation:DecorationNode" xmi:id="_cG7UtmaBEe6bwd8NmC1HOg" type="Comment_BodyLabel">
+        <element href="TapiStreamingGnmi.uml#_CfYvcN2UEeyisriSvKT5Lw"/>
+      </children>
+      <element href="TapiStreamingGnmi.uml#_CfYvcN2UEeyisriSvKT5Lw"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_cG7Ut2aBEe6bwd8NmC1HOg" x="-360" y="-40" width="161" height="21"/>
+    </children>
+    <children xsi:type="notation:Shape" xmi:id="_cG7UuGaBEe6bwd8NmC1HOg" type="Comment_Shape" fontColor="16711680" fontName="Segoe UI" fontHeight="6">
+      <eAnnotations xmi:id="_cG7UuWaBEe6bwd8NmC1HOg" source="PapyrusCSSForceValue">
+        <details xmi:id="_cG7UumaBEe6bwd8NmC1HOg" key="bold" value="true"/>
+        <details xmi:id="_cG7Uu2aBEe6bwd8NmC1HOg" key="italic" value="true"/>
+        <details xmi:id="_cG7UvGaBEe6bwd8NmC1HOg" key="fillColor" value="true"/>
+      </eAnnotations>
+      <children xsi:type="notation:DecorationNode" xmi:id="_cG7UvWaBEe6bwd8NmC1HOg" type="Comment_BodyLabel"/>
+      <element href="TapiStreamingGnmi.uml#_FwTQgEJcEe6tO8bOoJ4-CQ"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_cG7UvmaBEe6bwd8NmC1HOg" x="-360" y="220" width="161" height="21"/>
+    </children>
+    <children xsi:type="notation:Shape" xmi:id="_cHEeoGaBEe6bwd8NmC1HOg" type="Comment_Shape" fontColor="255" fontName="Segoe UI" fontHeight="6">
+      <eAnnotations xmi:id="_cHEeoWaBEe6bwd8NmC1HOg" source="PapyrusCSSForceValue">
+        <details xmi:id="_cHEeomaBEe6bwd8NmC1HOg" key="bold" value="true"/>
+        <details xmi:id="_cHEeo2aBEe6bwd8NmC1HOg" key="italic" value="true"/>
+        <details xmi:id="_cHEepGaBEe6bwd8NmC1HOg" key="fillColor" value="true"/>
+      </eAnnotations>
+      <children xsi:type="notation:DecorationNode" xmi:id="_cHEepWaBEe6bwd8NmC1HOg" type="Comment_BodyLabel"/>
+      <element href="TapiStreamingGnmi.uml#_QnzlkEJcEe6tO8bOoJ4-CQ"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_cHEepmaBEe6bwd8NmC1HOg" x="-360" y="260" width="161" height="21"/>
+    </children>
+    <children xsi:type="notation:Shape" xmi:id="_cHEep2aBEe6bwd8NmC1HOg" type="Comment_Shape" fontColor="128" fontName="Segoe UI" fontHeight="6">
+      <eAnnotations xmi:id="_cHEeqGaBEe6bwd8NmC1HOg" source="PapyrusCSSForceValue">
+        <details xmi:id="_cHEeqWaBEe6bwd8NmC1HOg" key="fontHeight" value="true"/>
+        <details xmi:id="_cHEeqmaBEe6bwd8NmC1HOg" key="bold" value="true"/>
+        <details xmi:id="_cHEeq2aBEe6bwd8NmC1HOg" key="italic" value="true"/>
+        <details xmi:id="_cHEerGaBEe6bwd8NmC1HOg" key="fillColor" value="true"/>
+      </eAnnotations>
+      <children xsi:type="notation:DecorationNode" xmi:id="_cHEerWaBEe6bwd8NmC1HOg" type="Comment_BodyLabel"/>
+      <element href="TapiStreamingGnmi.uml#_1tyPIEJbEe6tO8bOoJ4-CQ"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_cHEermaBEe6bwd8NmC1HOg" x="-360" y="180" width="162" height="21"/>
+    </children>
+    <children xsi:type="notation:Shape" xmi:id="_cHEer2aBEe6bwd8NmC1HOg" type="Comment_Shape" fontColor="32768" fontName="Segoe UI" fontHeight="6">
+      <eAnnotations xmi:id="_cHEesGaBEe6bwd8NmC1HOg" source="PapyrusCSSForceValue">
+        <details xmi:id="_cHEesWaBEe6bwd8NmC1HOg" key="bold" value="true"/>
+        <details xmi:id="_cHEesmaBEe6bwd8NmC1HOg" key="italic" value="true"/>
+        <details xmi:id="_cHEes2aBEe6bwd8NmC1HOg" key="fillColor" value="true"/>
+      </eAnnotations>
+      <children xsi:type="notation:DecorationNode" xmi:id="_cHEetGaBEe6bwd8NmC1HOg" type="Comment_BodyLabel"/>
+      <element href="TapiStreamingGnmi.uml#_e1WCUEJcEe6tO8bOoJ4-CQ"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_cHEetWaBEe6bwd8NmC1HOg" x="-360" y="300" width="161" height="21"/>
     </children>
     <styles xsi:type="notation:StringValueStyle" xmi:id="_DJT1kUJbEe6tO8bOoJ4-CQ" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xsi:type="notation:DiagramStyle" xmi:id="_DJT1kkJbEe6tO8bOoJ4-CQ"/>
@@ -8192,7 +8246,7 @@
       </children>
       <children xsi:type="notation:DecorationNode" xmi:id="_D2VvFFIVEe6m_d6KGfEFwg" type="Association_NameLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_D2VvFVIVEe6m_d6KGfEFwg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xsi:type="notation:Location" xmi:id="_D2VvFlIVEe6m_d6KGfEFwg" x="-13"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_D2VvFlIVEe6m_d6KGfEFwg" x="-13" y="-7"/>
       </children>
       <children xsi:type="notation:DecorationNode" xmi:id="_D2VvF1IVEe6m_d6KGfEFwg" type="Association_TargetRoleLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_D2VvGFIVEe6m_d6KGfEFwg" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -8204,7 +8258,7 @@
       </children>
       <children xsi:type="notation:DecorationNode" xmi:id="_D2VvHVIVEe6m_d6KGfEFwg" type="Association_SourceMultiplicityLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_D2VvHlIVEe6m_d6KGfEFwg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xsi:type="notation:Location" xmi:id="_D2VvH1IVEe6m_d6KGfEFwg" x="3" y="19"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_D2VvH1IVEe6m_d6KGfEFwg" x="7" y="-31"/>
       </children>
       <children xsi:type="notation:DecorationNode" xmi:id="_D2VvIFIVEe6m_d6KGfEFwg" type="Association_TargetMultiplicityLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_D2VvIVIVEe6m_d6KGfEFwg" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -8214,7 +8268,7 @@
       <element href="TapiStreamingGnmi.uml#_S1iBsFIQEe6m_d6KGfEFwg"/>
       <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_D2VvJ1IVEe6m_d6KGfEFwg" points="[-30, 10, -643984, -643984]$[-90, 30, -643984, -643984]"/>
       <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_D2VvKFIVEe6m_d6KGfEFwg" id="(0.5607476635514018,1.0)"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_D2VvKVIVEe6m_d6KGfEFwg" id="(0.3674540682414698,0.0)"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_D2VvKVIVEe6m_d6KGfEFwg" id="(0.4066543438077634,0.0)"/>
     </edges>
     <edges xsi:type="notation:Connector" xmi:id="_D2VvKlIVEe6m_d6KGfEFwg" type="Association_Edge" source="_D2Vuk1IVEe6m_d6KGfEFwg" target="_D2VwF1IVEe6m_d6KGfEFwg" routing="Rectilinear">
       <eAnnotations xmi:id="_D2VvK1IVEe6m_d6KGfEFwg" source="PapyrusCSSForceValue">
@@ -8240,7 +8294,7 @@
       </children>
       <children xsi:type="notation:DecorationNode" xmi:id="_D2VvO1IVEe6m_d6KGfEFwg" type="Association_SourceMultiplicityLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_D2VvPFIVEe6m_d6KGfEFwg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xsi:type="notation:Location" xmi:id="_D2VvPVIVEe6m_d6KGfEFwg" x="13" y="-5"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_D2VvPVIVEe6m_d6KGfEFwg" x="29" y="-7"/>
       </children>
       <children xsi:type="notation:DecorationNode" xmi:id="_D2VvPlIVEe6m_d6KGfEFwg" type="Association_TargetMultiplicityLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_D2VvP1IVEe6m_d6KGfEFwg" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -8248,9 +8302,9 @@
       </children>
       <styles xsi:type="notation:FontStyle" xmi:id="_D2VvQVIVEe6m_d6KGfEFwg" fontName="Segoe UI" fontHeight="6"/>
       <element href="TapiStreamingGnmi.uml#_ZhiA0EOEEe6bIJjw8ZnZGQ"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_D2VvRVIVEe6m_d6KGfEFwg" points="[490, 150, -643984, -643984]$[450, 150, -643984, -643984]$[450, 370, -643984, -643984]$[291, 370, -643984, -643984]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_D2VvRlIVEe6m_d6KGfEFwg" id="(0.0,0.6557377049180327)"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_D2VvR1IVEe6m_d6KGfEFwg" id="(1.0,0.09049773755656108)"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_D2VvRVIVEe6m_d6KGfEFwg" points="[720, 160, -643984, -643984]$[560, 160, -643984, -643984]$[560, 400, -643984, -643984]$[381, 400, -643984, -643984]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_D2VvRlIVEe6m_d6KGfEFwg" id="(0.0,0.7407407407407407)"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_D2VvR1IVEe6m_d6KGfEFwg" id="(1.0,0.18099547511312217)"/>
     </edges>
     <edges xsi:type="notation:Connector" xmi:id="_D2VvSFIVEe6m_d6KGfEFwg" type="Association_Edge" source="_D2VvZlIVEe6m_d6KGfEFwg" target="_D2Vuk1IVEe6m_d6KGfEFwg" routing="Rectilinear" lineColor="0">
       <eAnnotations xmi:id="_D2VvSVIVEe6m_d6KGfEFwg" source="PapyrusCSSForceValue">
@@ -8261,12 +8315,12 @@
       <children xsi:type="notation:DecorationNode" xmi:id="_D2VvTVIVEe6m_d6KGfEFwg" type="Association_StereotypeLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_D2VvTlIVEe6m_d6KGfEFwg" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <element href="TapiStreamingGnmi.uml#_SyXM4KYBEe2n-fmfRwdlPg"/>
-        <layoutConstraint xsi:type="notation:Location" xmi:id="_D2VvT1IVEe6m_d6KGfEFwg" x="-57" y="5"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_D2VvT1IVEe6m_d6KGfEFwg" x="-52" y="7"/>
       </children>
       <children xsi:type="notation:DecorationNode" xmi:id="_D2VvUFIVEe6m_d6KGfEFwg" type="Association_NameLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_D2VvUVIVEe6m_d6KGfEFwg" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <element href="TapiStreamingGnmi.uml#_SyXM4KYBEe2n-fmfRwdlPg"/>
-        <layoutConstraint xsi:type="notation:Location" xmi:id="_D2VvUlIVEe6m_d6KGfEFwg" x="-52" y="-15"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_D2VvUlIVEe6m_d6KGfEFwg" x="-38" y="-13"/>
       </children>
       <children xsi:type="notation:DecorationNode" xmi:id="_D2VvU1IVEe6m_d6KGfEFwg" type="Association_TargetRoleLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_D2VvVFIVEe6m_d6KGfEFwg" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -8292,7 +8346,7 @@
       <element href="TapiStreamingGnmi.uml#_SyXM4KYBEe2n-fmfRwdlPg"/>
       <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_D2VvY1IVEe6m_d6KGfEFwg" points="[261, 0, -643984, -643984]$[600, 0, -643984, -643984]$[600, 100, -643984, -643984]"/>
       <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_D2VvZFIVEe6m_d6KGfEFwg" id="(1.0,0.6666666666666666)"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_D2VvZVIVEe6m_d6KGfEFwg" id="(0.33222591362126247,0.0)"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_D2VvZVIVEe6m_d6KGfEFwg" id="(0.29925187032418954,0.0)"/>
     </edges>
     <edges xsi:type="notation:Connector" xmi:id="_D2Vv21IVEe6m_d6KGfEFwg" type="Association_Edge" source="_D2Vuk1IVEe6m_d6KGfEFwg" target="_D2VsQFIVEe6m_d6KGfEFwg">
       <eAnnotations xmi:id="_D2Vv3FIVEe6m_d6KGfEFwg" source="PapyrusCSSForceValue">
@@ -8302,11 +8356,11 @@
       </eAnnotations>
       <children xsi:type="notation:DecorationNode" xmi:id="_D2Vv4FIVEe6m_d6KGfEFwg" type="Association_StereotypeLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_D2Vv4VIVEe6m_d6KGfEFwg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xsi:type="notation:Location" xmi:id="_D2Vv4lIVEe6m_d6KGfEFwg" x="-1" y="-5"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_D2Vv4lIVEe6m_d6KGfEFwg" y="-7"/>
       </children>
       <children xsi:type="notation:DecorationNode" xmi:id="_D2Vv41IVEe6m_d6KGfEFwg" type="Association_NameLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_D2Vv5FIVEe6m_d6KGfEFwg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xsi:type="notation:Location" xmi:id="_D2Vv5VIVEe6m_d6KGfEFwg" x="9" y="15"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_D2Vv5VIVEe6m_d6KGfEFwg" x="4" y="13"/>
       </children>
       <children xsi:type="notation:DecorationNode" xmi:id="_D2Vv5lIVEe6m_d6KGfEFwg" type="Association_TargetRoleLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_D2Vv51IVEe6m_d6KGfEFwg" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -8318,7 +8372,7 @@
       </children>
       <children xsi:type="notation:DecorationNode" xmi:id="_D2Vv7FIVEe6m_d6KGfEFwg" type="Association_SourceMultiplicityLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_D2Vv7VIVEe6m_d6KGfEFwg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xsi:type="notation:Location" xmi:id="_D2Vv7lIVEe6m_d6KGfEFwg" x="16" y="-5"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_D2Vv7lIVEe6m_d6KGfEFwg" x="29" y="-7"/>
       </children>
       <children xsi:type="notation:DecorationNode" xmi:id="_D2Vv71IVEe6m_d6KGfEFwg" type="Association_TargetMultiplicityLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_D2Vv8FIVEe6m_d6KGfEFwg" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -8327,7 +8381,7 @@
       <styles xsi:type="notation:FontStyle" xmi:id="_D2Vv8lIVEe6m_d6KGfEFwg" fontName="Segoe UI" fontHeight="6"/>
       <element href="TapiStreamingGnmi.uml#_VET7gFISEe6m_d6KGfEFwg"/>
       <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_D2Vv9lIVEe6m_d6KGfEFwg" points="[510, 110, -643984, -643984]$[330, 90, -643984, -643984]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_D2Vv91IVEe6m_d6KGfEFwg" id="(0.0,0.32786885245901637)"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_D2Vv91IVEe6m_d6KGfEFwg" id="(0.0,0.24691358024691357)"/>
       <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_D2Vv-FIVEe6m_d6KGfEFwg" id="(1.0,0.09950248756218906)"/>
     </edges>
     <edges xsi:type="notation:Connector" xmi:id="_D2Vv-VIVEe6m_d6KGfEFwg" type="Association_Edge" source="_D2VvZlIVEe6m_d6KGfEFwg" target="_D2VwF1IVEe6m_d6KGfEFwg">
@@ -8338,11 +8392,11 @@
       </eAnnotations>
       <children xsi:type="notation:DecorationNode" xmi:id="_D2Vv_lIVEe6m_d6KGfEFwg" type="Association_StereotypeLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_D2Vv_1IVEe6m_d6KGfEFwg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xsi:type="notation:Location" xmi:id="_D2VwAFIVEe6m_d6KGfEFwg" x="-125" y="-21"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_D2VwAFIVEe6m_d6KGfEFwg" x="-123" y="-20"/>
       </children>
       <children xsi:type="notation:DecorationNode" xmi:id="_D2VwAVIVEe6m_d6KGfEFwg" type="Association_NameLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_D2VwAlIVEe6m_d6KGfEFwg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xsi:type="notation:Location" xmi:id="_D2VwA1IVEe6m_d6KGfEFwg" x="-145" y="-13"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_D2VwA1IVEe6m_d6KGfEFwg" x="-143" y="-19"/>
       </children>
       <children xsi:type="notation:DecorationNode" xmi:id="_D2VwBFIVEe6m_d6KGfEFwg" type="Association_TargetRoleLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_D2VwBVIVEe6m_d6KGfEFwg" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -8354,7 +8408,7 @@
       </children>
       <children xsi:type="notation:DecorationNode" xmi:id="_D2VwClIVEe6m_d6KGfEFwg" type="Association_SourceMultiplicityLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_D2VwC1IVEe6m_d6KGfEFwg" name="IS_UPDATED_POSITION" booleanValue="true"/>
-        <layoutConstraint xsi:type="notation:Location" xmi:id="_D2VwDFIVEe6m_d6KGfEFwg" x="5" y="13"/>
+        <layoutConstraint xsi:type="notation:Location" xmi:id="_D2VwDFIVEe6m_d6KGfEFwg" x="7" y="-31"/>
       </children>
       <children xsi:type="notation:DecorationNode" xmi:id="_D2VwDVIVEe6m_d6KGfEFwg" type="Association_TargetMultiplicityLabel">
         <styles xsi:type="notation:BooleanValueStyle" xmi:id="_D2VwDlIVEe6m_d6KGfEFwg" name="IS_UPDATED_POSITION" booleanValue="true"/>
@@ -8364,97 +8418,97 @@
       <element href="TapiStreamingGnmi.uml#__d9xQEODEe6bIJjw8ZnZGQ"/>
       <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_D2VwFFIVEe6m_d6KGfEFwg" points="[10, 10, -643984, -643984]$[-10, 110, -643984, -643984]"/>
       <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_D2VwFVIVEe6m_d6KGfEFwg" id="(0.06230529595015576,1.0)"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_D2VwFlIVEe6m_d6KGfEFwg" id="(0.10498687664041995,0.0)"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_D2VwFlIVEe6m_d6KGfEFwg" id="(0.07393715341959335,0.0)"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_4HFydFecEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_D2VsQFIVEe6m_d6KGfEFwg" target="_4HFycFecEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_4HFydVecEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_4HFyeVecEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_9uyRn2aAEe6bwd8NmC1HOg" type="StereotypeCommentLink" source="_D2VsQFIVEe6m_d6KGfEFwg" target="_9uyRm2aAEe6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_9uyRoGaAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_9uyRpGaAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_KRgyMFIQEe6m_d6KGfEFwg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_4HFydlecEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_4HFyd1ecEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_4HFyeFecEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_9uyRoWaAEe6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_9uyRomaAEe6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_9uyRo2aAEe6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_4HyWBFecEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_D2Vuk1IVEe6m_d6KGfEFwg" target="_4HyWAFecEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_4HyWBVecEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_4HyWCVecEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_9vtepGaAEe6bwd8NmC1HOg" type="StereotypeCommentLink" source="_D2Vuk1IVEe6m_d6KGfEFwg" target="_9vteoGaAEe6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_9vtepWaAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_9vteqWaAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_FCwpUKYBEe2n-fmfRwdlPg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_4HyWBlecEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_4HyWB1ecEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_4HyWCFecEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_9vtepmaAEe6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_9vtep2aAEe6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_9vteqGaAEe6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_4H8uFFecEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_D2VvKlIVEe6m_d6KGfEFwg" target="_4H8uEFecEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_4H8uFVecEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_4H8uGVecEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_9v66AWaAEe6bwd8NmC1HOg" type="StereotypeCommentLink" source="_D2VvKlIVEe6m_d6KGfEFwg" target="_9v6S8GaAEe6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_9v66AmaAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_9v66BmaAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_ZhiA0EOEEe6bIJjw8ZnZGQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_4H8uFlecEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_4H8uF1ecEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_4H8uGFecEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_9v66A2aAEe6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_9v66BGaAEe6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_9v66BWaAEe6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_4IAYdFecEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_D2Vv21IVEe6m_d6KGfEFwg" target="_4IAYcFecEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_4IAYdVecEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_4IAYeVecEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_9v_yhGaAEe6bwd8NmC1HOg" type="StereotypeCommentLink" source="_D2Vv21IVEe6m_d6KGfEFwg" target="_9v_ygGaAEe6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_9v_yhWaAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_9v_yiWaAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_VET7gFISEe6m_d6KGfEFwg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_4IAYdlecEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_4IAYd1ecEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_4IAYeFecEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_9v_yhmaAEe6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_9v_yh2aAEe6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_9v_yiGaAEe6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_4ILXlFecEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_D2VvZlIVEe6m_d6KGfEFwg" target="_4ILXkFecEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_4ILXlVecEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_4ILXmVecEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_9wKKm2aAEe6bwd8NmC1HOg" type="StereotypeCommentLink" source="_D2VvZlIVEe6m_d6KGfEFwg" target="_9wKKl2aAEe6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_9wKKnGaAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_9wKKoGaAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_Aow5sKFgEe2n-fmfRwdlPg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_4ILXllecEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_4ILXl1ecEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_4ILXmFecEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_9wKKnWaAEe6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_9wKKnmaAEe6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_9wKKn2aAEe6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_4IVIlFecEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_D2VvDFIVEe6m_d6KGfEFwg" target="_4IVIkFecEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_4IVIlVecEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_4IVImVecEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_9wVw6WaAEe6bwd8NmC1HOg" type="StereotypeCommentLink" source="_D2VvDFIVEe6m_d6KGfEFwg" target="_9wVw5WaAEe6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_9wVw6maAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_9wVw7maAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_S1iBsFIQEe6m_d6KGfEFwg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_4IVIllecEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_4IVIl1ecEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_4IVImFecEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_9wVw62aAEe6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_9wVw7GaAEe6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_9wVw7WaAEe6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_4IYy9FecEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_D2VvSFIVEe6m_d6KGfEFwg" target="_4IYy8FecEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_4IYy9VecEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_4IZaAlecEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_9wfhx2aAEe6bwd8NmC1HOg" type="StereotypeCommentLink" source="_D2VvSFIVEe6m_d6KGfEFwg" target="_9wfhw2aAEe6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_9wfhyGaAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_9wfhzGaAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_SyXM4KYBEe2n-fmfRwdlPg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_4IYy9lecEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_4IZaAFecEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_4IZaAVecEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_9wfhyWaAEe6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_9wfhymaAEe6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_9wfhy2aAEe6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_4IdEZFecEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_D2Vv-VIVEe6m_d6KGfEFwg" target="_4IdEYFecEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_4IdEZVecEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_4IdEaVecEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_9wfh2GaAEe6bwd8NmC1HOg" type="StereotypeCommentLink" source="_D2Vv-VIVEe6m_d6KGfEFwg" target="_9wfh1GaAEe6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_9wfh2WaAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_9wfh3WaAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#__d9xQEODEe6bIJjw8ZnZGQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_4IdEZlecEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_4IdEZ1ecEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_4IdEaFecEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_9wfh2maAEe6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_9wfh22aAEe6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_9wfh3GaAEe6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_4Irt5FecEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_D2VwF1IVEe6m_d6KGfEFwg" target="_4Irt4FecEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_4Irt5VecEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_4Irt6VecEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_9wycu2aAEe6bwd8NmC1HOg" type="StereotypeCommentLink" source="_D2VwF1IVEe6m_d6KGfEFwg" target="_9wyct2aAEe6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_9wycvGaAEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_9wycwGaAEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_406Q8KFhEe2n-fmfRwdlPg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_4Irt5lecEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_4Irt51ecEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_4Irt6FecEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_9wycvWaAEe6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_9wycvmaAEe6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_9wycv2aAEe6bwd8NmC1HOg"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_TSlUUEJdEe6tO8bOoJ4-CQ" type="PapyrusUMLClassDiagram" name="RelatedClasses" measurementUnit="Pixel">
@@ -8607,7 +8661,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="_vAqoG0JdEe6tO8bOoJ4-CQ"/>
       </children>
       <element href="TapiStreamingGnmi.uml#_406Q8KFhEe2n-fmfRwdlPg"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_vAqoRUJdEe6tO8bOoJ4-CQ" width="381" height="281"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_vAqoRUJdEe6tO8bOoJ4-CQ" x="-80" width="461" height="281"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_vAqoRkJdEe6tO8bOoJ4-CQ" type="Class_Shape" fontName="Segoe UI" fontHeight="6" fillColor="10011046">
       <eAnnotations xmi:id="_vAqoR0JdEe6tO8bOoJ4-CQ" source="PapyrusCSSForceValue">
@@ -8683,7 +8737,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="_vAqpVkJdEe6tO8bOoJ4-CQ"/>
       </children>
       <element href="TapiOam.uml#_-2fMYF0KEeipas1p-rFJBA"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_vAqpgEJdEe6tO8bOoJ4-CQ" x="760" y="220" width="241" height="140"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_vAqpgEJdEe6tO8bOoJ4-CQ" x="800" y="220" width="301" height="140"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_vA0WRUJdEe6tO8bOoJ4-CQ" type="Class_Shape" fontName="Segoe UI" fontHeight="6" fillColor="10011046">
       <eAnnotations xmi:id="_vA0WRkJdEe6tO8bOoJ4-CQ" source="PapyrusCSSForceValue">
@@ -8714,7 +8768,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="_vA0WW0JdEe6tO8bOoJ4-CQ"/>
       </children>
       <element href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_vA0WhUJdEe6tO8bOoJ4-CQ" x="520" y="180" width="220" height="40"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_vA0WhUJdEe6tO8bOoJ4-CQ" x="520" y="180" width="261" height="40"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_vA0WhkJdEe6tO8bOoJ4-CQ" type="Class_Shape" fontName="Segoe UI" fontHeight="6" fillColor="13420443">
       <eAnnotations xmi:id="_vA0Wh0JdEe6tO8bOoJ4-CQ" source="PapyrusCSSForceValue">
@@ -8745,7 +8799,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="_vA0WnEJdEe6tO8bOoJ4-CQ"/>
       </children>
       <element href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_vA0WxkJdEe6tO8bOoJ4-CQ" x="520" y="120" width="221" height="40"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_vA0WxkJdEe6tO8bOoJ4-CQ" x="520" y="120" width="262" height="40"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_vA0XMUJdEe6tO8bOoJ4-CQ" type="Class_Shape" fontName="Segoe UI" fontHeight="6" fillColor="10011046">
       <eAnnotations xmi:id="_vA0XMkJdEe6tO8bOoJ4-CQ" source="PapyrusCSSForceValue">
@@ -8794,7 +8848,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="_vA0Xq0JdEe6tO8bOoJ4-CQ"/>
       </children>
       <element href="TapiOam.uml#_RRNb8DU7Eem_pr37XaewKQ"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_vA0X1UJdEe6tO8bOoJ4-CQ" x="520" y="300" width="221" height="61"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_vA0X1UJdEe6tO8bOoJ4-CQ" x="520" y="300" width="262" height="61"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_vA0YF0JdEe6tO8bOoJ4-CQ" type="Class_Shape" fontName="Segoe UI" fontHeight="6" fillColor="10011046">
       <eAnnotations xmi:id="_vA0YGEJdEe6tO8bOoJ4-CQ" source="PapyrusCSSForceValue">
@@ -8902,7 +8956,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="_vA0Z6kJdEe6tO8bOoJ4-CQ"/>
       </children>
       <element href="TapiOam.uml#_vnyfgF0IEeipas1p-rFJBA"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_vA0aFEJdEe6tO8bOoJ4-CQ" x="760" width="241" height="201"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_vA0aFEJdEe6tO8bOoJ4-CQ" x="800" width="301" height="201"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_vA0a8kJdEe6tO8bOoJ4-CQ" type="Class_Shape" fontName="Segoe UI" fontHeight="6" fillColor="10011046">
       <eAnnotations xmi:id="_vA0a80JdEe6tO8bOoJ4-CQ" source="PapyrusCSSForceValue">
@@ -8933,7 +8987,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="_vA0bCEJdEe6tO8bOoJ4-CQ"/>
       </children>
       <element href="TapiOam.uml#_CE0kkLwmEeSpn78DYJKtkA"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_vA0bMkJdEe6tO8bOoJ4-CQ" x="520" y="240" width="220" height="41"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_vA0bMkJdEe6tO8bOoJ4-CQ" x="520" y="240" width="261" height="41"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="__72TuEJdEe6tO8bOoJ4-CQ" type="Comment_Shape" fontName="Segoe UI" fontHeight="6" fillColor="10011046">
       <eAnnotations xmi:id="__72TuUJdEe6tO8bOoJ4-CQ" source="PapyrusCSSForceValue">
@@ -8943,7 +8997,7 @@
       </eAnnotations>
       <children xsi:type="notation:DecorationNode" xmi:id="__72TvUJdEe6tO8bOoJ4-CQ" type="Comment_BodyLabel"/>
       <element href="TapiStreamingGnmi.uml#_Ql-pwLHGEe2tjo53LmkUFA"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="__72TvkJdEe6tO8bOoJ4-CQ" x="420" y="80" width="141" height="21"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="__72TvkJdEe6tO8bOoJ4-CQ" x="420" y="80" width="181" height="21"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="__72Tv0JdEe6tO8bOoJ4-CQ" type="Comment_Shape" fontName="Segoe UI" fontHeight="6" fillColor="13420443">
       <eAnnotations xmi:id="__72TwEJdEe6tO8bOoJ4-CQ" source="PapyrusCSSForceValue">
@@ -8953,7 +9007,7 @@
       </eAnnotations>
       <children xsi:type="notation:DecorationNode" xmi:id="__72TxEJdEe6tO8bOoJ4-CQ" type="Comment_BodyLabel"/>
       <element href="TapiStreamingGnmi.uml#_U6ZXwLv3Ee2tPvK7TLwO7Q"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="__72TxUJdEe6tO8bOoJ4-CQ" x="420" y="40" width="141" height="21"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="__72TxUJdEe6tO8bOoJ4-CQ" x="420" y="40" width="181" height="21"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="__72TxkJdEe6tO8bOoJ4-CQ" type="Comment_Shape" fontName="Segoe UI" fontHeight="6" fillColor="12621752">
       <eAnnotations xmi:id="__72Tx0JdEe6tO8bOoJ4-CQ" source="PapyrusCSSForceValue">
@@ -8966,7 +9020,7 @@
         <element href="TapiStreamingGnmi.uml#_CfYvcN2UEeyisriSvKT5Lw"/>
       </children>
       <element href="TapiStreamingGnmi.uml#_CfYvcN2UEeyisriSvKT5Lw"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="__72TzUJdEe6tO8bOoJ4-CQ" x="420" width="141" height="21"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="__72TzUJdEe6tO8bOoJ4-CQ" x="420" width="181" height="21"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_R_e4RkJeEe6tO8bOoJ4-CQ" type="Comment_Shape" fontColor="255" fontName="Segoe UI" fontHeight="6">
       <eAnnotations xmi:id="_R_e4R0JeEe6tO8bOoJ4-CQ" source="PapyrusCSSForceValue">
@@ -8978,61 +9032,61 @@
       <element href="TapiStreamingGnmi.uml#_QnzlkEJcEe6tO8bOoJ4-CQ"/>
       <layoutConstraint xsi:type="notation:Bounds" xmi:id="_R_e4S0JeEe6tO8bOoJ4-CQ" y="300" width="121" height="21"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_hVJkUFefEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_hVJkUVefEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_hVJkU1efEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_ksElkGaBEe6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_ksElkWaBEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_ksElk2aBEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_406Q8KFhEe2n-fmfRwdlPg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_hVJkUlefEe6mE7NoRC7Zaw" x="200"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_ksElkmaBEe6bwd8NmC1HOg" x="200"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_hVil4FefEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_hVil4VefEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_hVil41efEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_kskU02aBEe6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_kskU1GaBEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_kskU1maBEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiOam.uml#_-2fMYF0KEeipas1p-rFJBA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_hVil4lefEe6mE7NoRC7Zaw" x="960" y="220"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_kskU1WaBEe6bwd8NmC1HOg" x="960" y="220"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_hWBuEFefEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_hWBuEVefEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_hWBuE1efEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_ktJjo2aBEe6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_ktJjpGaBEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_ktJjpmaBEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_hWBuElefEe6mE7NoRC7Zaw" x="720" y="180"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_ktJjpWaBEe6bwd8NmC1HOg" x="720" y="180"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_hWPJcFefEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_hWPJcVefEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_hWPJc1efEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_ktcek2aBEe6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_ktcelGaBEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_ktcelmaBEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_hWPJclefEe6mE7NoRC7Zaw" x="720" y="120"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_ktcelWaBEe6bwd8NmC1HOg" x="720" y="120"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_hWck0FefEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_hWck0VefEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_hWdL4FefEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_ktwAkGaBEe6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_ktwAkWaBEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_ktwAk2aBEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiOam.uml#_RRNb8DU7Eem_pr37XaewKQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_hWck0lefEe6mE7NoRC7Zaw" x="720" y="300"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_ktwAkmaBEe6bwd8NmC1HOg" x="720" y="300"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_hWxU8FefEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_hWxU8VefEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_hWx8AFefEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_kuIbEGaBEe6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_kuIbEWaBEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_kuIbE2aBEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiOam.uml#_vnyfgF0IEeipas1p-rFJBA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_hWxU8lefEe6mE7NoRC7Zaw" x="960"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_kuIbEmaBEe6bwd8NmC1HOg" x="960"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_hXaOIFefEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_hXaOIVefEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_hXaOI1efEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_ku-voGaBEe6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_ku-voWaBEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_ku-vo2aBEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiOam.uml#_CE0kkLwmEeSpn78DYJKtkA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_hXaOIlefEe6mE7NoRC7Zaw" x="720" y="240"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_ku-vomaBEe6bwd8NmC1HOg" x="720" y="240"/>
     </children>
     <styles xsi:type="notation:StringValueStyle" xmi:id="_TSlUUUJdEe6tO8bOoJ4-CQ" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xsi:type="notation:DiagramStyle" xmi:id="_TSlUUkJdEe6tO8bOoJ4-CQ"/>
@@ -9148,75 +9202,75 @@
       <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_vA0YFUJdEe6tO8bOoJ4-CQ" id="(1.0,0.7117437722419929)"/>
       <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_vA0YFkJdEe6tO8bOoJ4-CQ" id="(0.0,0.5)"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_hVJkVFefEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_vAqk8EJdEe6tO8bOoJ4-CQ" target="_hVJkUFefEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_hVJkVVefEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_hVJkWVefEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_ksEllGaBEe6bwd8NmC1HOg" type="StereotypeCommentLink" source="_vAqk8EJdEe6tO8bOoJ4-CQ" target="_ksElkGaBEe6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_ksEllWaBEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_ksElmWaBEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreamingGnmi.uml#_406Q8KFhEe2n-fmfRwdlPg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_hVJkVlefEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_hVJkV1efEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_hVJkWFefEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_ksEllmaBEe6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_ksEll2aBEe6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_ksElmGaBEe6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_hVil5FefEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_vAqoRkJdEe6tO8bOoJ4-CQ" target="_hVil4FefEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_hVil5VefEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_hVil6VefEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_kskU12aBEe6bwd8NmC1HOg" type="StereotypeCommentLink" source="_vAqoRkJdEe6tO8bOoJ4-CQ" target="_kskU02aBEe6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_kskU2GaBEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_kskU3GaBEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiOam.uml#_-2fMYF0KEeipas1p-rFJBA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_hVil5lefEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_hVil51efEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_hVil6FefEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_kskU2WaBEe6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_kskU2maBEe6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_kskU22aBEe6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_hWCVIFefEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_vA0WRUJdEe6tO8bOoJ4-CQ" target="_hWBuEFefEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_hWCVIVefEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_hWCVJVefEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_ktJjp2aBEe6bwd8NmC1HOg" type="StereotypeCommentLink" source="_vA0WRUJdEe6tO8bOoJ4-CQ" target="_ktJjo2aBEe6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_ktJjqGaBEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_ktJjrGaBEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_hWCVIlefEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_hWCVI1efEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_hWCVJFefEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_ktJjqWaBEe6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_ktJjqmaBEe6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_ktJjq2aBEe6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_hWPJdFefEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_vA0WhkJdEe6tO8bOoJ4-CQ" target="_hWPJcFefEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_hWPJdVefEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_hWPwgFefEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_ktcel2aBEe6bwd8NmC1HOg" type="StereotypeCommentLink" source="_vA0WhkJdEe6tO8bOoJ4-CQ" target="_ktcek2aBEe6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_ktcemGaBEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_ktcenGaBEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_hWPJdlefEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_hWPJd1efEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_hWPJeFefEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_ktcemWaBEe6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_ktcemmaBEe6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_ktcem2aBEe6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_hWdL4VefEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_vA0XMUJdEe6tO8bOoJ4-CQ" target="_hWck0FefEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_hWdL4lefEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_hWdL5lefEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_ktwAlGaBEe6bwd8NmC1HOg" type="StereotypeCommentLink" source="_vA0XMUJdEe6tO8bOoJ4-CQ" target="_ktwAkGaBEe6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_ktwAlWaBEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_ktwnomaBEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiOam.uml#_RRNb8DU7Eem_pr37XaewKQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_hWdL41efEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_hWdL5FefEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_hWdL5VefEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_ktwAlmaBEe6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_ktwnoGaBEe6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_ktwnoWaBEe6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_hWx8AVefEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_vA0YF0JdEe6tO8bOoJ4-CQ" target="_hWxU8FefEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_hWx8AlefEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_hWx8BlefEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_kuIbFGaBEe6bwd8NmC1HOg" type="StereotypeCommentLink" source="_vA0YF0JdEe6tO8bOoJ4-CQ" target="_kuIbEGaBEe6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_kuIbFWaBEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_kuIbGWaBEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiOam.uml#_vnyfgF0IEeipas1p-rFJBA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_hWx8A1efEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_hWx8BFefEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_hWx8BVefEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_kuIbFmaBEe6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_kuIbF2aBEe6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_kuIbGGaBEe6bwd8NmC1HOg"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_hXaOJFefEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_vA0a8kJdEe6tO8bOoJ4-CQ" target="_hXaOIFefEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_hXaOJVefEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_hXa1MlefEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_ku-vpGaBEe6bwd8NmC1HOg" type="StereotypeCommentLink" source="_vA0a8kJdEe6tO8bOoJ4-CQ" target="_ku-voGaBEe6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_ku-vpWaBEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_ku-vqWaBEe6bwd8NmC1HOg" name="BASE_ELEMENT">
         <eObjectValue href="TapiOam.uml#_CE0kkLwmEeSpn78DYJKtkA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_hXaOJlefEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_hXa1MFefEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_hXa1MVefEe6mE7NoRC7Zaw"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_ku-vpmaBEe6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_ku-vp2aBEe6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_ku-vqGaBEe6bwd8NmC1HOg"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_c-ZM8EcsEe6bIJjw8ZnZGQ" type="PapyrusUMLClassDiagram" name="DataTypes" measurementUnit="Pixel">
@@ -9479,7 +9533,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="__k02s0csEe6bIJjw8ZnZGQ"/>
       </children>
       <element href="TapiStreamingGnmi.uml#_tGy2YKJFEe2n-fmfRwdlPg"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="__k02t0csEe6bIJjw8ZnZGQ" y="40" width="341" height="161"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="__k02t0csEe6bIJjw8ZnZGQ" x="-260" y="40" width="421" height="161"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="__k2DkEcsEe6bIJjw8ZnZGQ" type="Enumeration_Shape" fontName="Segoe UI" fontHeight="6" fillColor="10265827">
       <eAnnotations xmi:id="__k2DkUcsEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
@@ -9723,7 +9777,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="__k2EMkcsEe6bIJjw8ZnZGQ"/>
       </children>
       <element href="TapiCommon.uml#_xnfcMEyXEe2yGsF8121Sxw"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="__k2ENkcsEe6bIJjw8ZnZGQ" x="1200" y="140" width="161" height="441"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="__k2ENkcsEe6bIJjw8ZnZGQ" x="1460" y="140" width="241" height="441"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="__k2EN0csEe6bIJjw8ZnZGQ" type="Enumeration_Shape" fontName="Segoe UI" fontHeight="6" fillColor="8905185">
       <eAnnotations xmi:id="__k2EOEcsEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
@@ -9818,7 +9872,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="__k2Eh0csEe6bIJjw8ZnZGQ"/>
       </children>
       <element href="TapiStreamingGnmi.uml#_nwJQkKYQEe2n-fmfRwdlPg"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="__k2Ei0csEe6bIJjw8ZnZGQ" y="280" width="181" height="101"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="__k2Ei0csEe6bIJjw8ZnZGQ" x="-260" y="260" width="241" height="121"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="__k2qoEcsEe6bIJjw8ZnZGQ" type="Enumeration_Shape" fontName="Segoe UI" fontHeight="6" fillColor="8905185">
       <eAnnotations xmi:id="__k2qoUcsEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
@@ -9913,7 +9967,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="__k2q8EcsEe6bIJjw8ZnZGQ"/>
       </children>
       <element href="TapiStreamingGnmi.uml#_7yFhkKbkEe2n-fmfRwdlPg"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="__k2q9EcsEe6bIJjw8ZnZGQ" x="640" y="420" width="221" height="101"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="__k2q9EcsEe6bIJjw8ZnZGQ" x="640" y="420" width="301" height="121"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="__k2q9UcsEe6bIJjw8ZnZGQ" type="Enumeration_Shape" fontName="Segoe UI" fontHeight="6" fillColor="8905185">
       <eAnnotations xmi:id="__k2q9kcsEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
@@ -10382,7 +10436,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="__k2rl0csEe6bIJjw8ZnZGQ"/>
       </children>
       <element href="TapiStreamingGnmi.uml#__6_sAEcnEe6bIJjw8ZnZGQ"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="__k2rm0csEe6bIJjw8ZnZGQ" x="880" y="140" width="261" height="441"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="__k2rm0csEe6bIJjw8ZnZGQ" x="1000" y="140" width="381" height="441"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="__k3RsEcsEe6bIJjw8ZnZGQ" type="Enumeration_Shape" fontName="Segoe UI" fontHeight="6" fillColor="8905185">
       <eAnnotations xmi:id="__k3RsUcsEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
@@ -10531,7 +10585,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="__k3SM0csEe6bIJjw8ZnZGQ"/>
       </children>
       <element href="TapiStreamingGnmi.uml#_FbS6sKbpEe2n-fmfRwdlPg"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="__k3SN0csEe6bIJjw8ZnZGQ" x="320" y="420" width="301" height="161"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="__k3SN0csEe6bIJjw8ZnZGQ" x="200" y="420" width="421" height="161"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="__k34wEcsEe6bIJjw8ZnZGQ" type="Enumeration_Shape" fontName="Segoe UI" fontHeight="6" fillColor="8905185">
       <eAnnotations xmi:id="__k34wUcsEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
@@ -10626,7 +10680,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="__k35EEcsEe6bIJjw8ZnZGQ"/>
       </children>
       <element href="TapiStreamingGnmi.uml#_OSJcgKZuEe2n-fmfRwdlPg"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="__k35FEcsEe6bIJjw8ZnZGQ" x="200" y="280" width="181" height="101"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="__k35FEcsEe6bIJjw8ZnZGQ" y="260" width="261" height="121"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="__k35FUcsEe6bIJjw8ZnZGQ" type="Class_Shape" fontName="Segoe UI" fontHeight="6" fillColor="12621752">
       <eAnnotations xmi:id="__k35FkcsEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
@@ -10737,7 +10791,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="__k4g7EcsEe6bIJjw8ZnZGQ"/>
       </children>
       <element href="TapiStreamingGnmi.uml#_406Q8KFhEe2n-fmfRwdlPg"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="__k4hFkcsEe6bIJjw8ZnZGQ" x="440" y="40" width="381" height="101"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="__k4hFkcsEe6bIJjw8ZnZGQ" x="360" y="40" width="541" height="101"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_jU4GgEcvEe6bIJjw8ZnZGQ" type="Comment_Shape" fontName="Segoe UI" fontHeight="6" fillColor="12621752">
       <eAnnotations xmi:id="_jU4GgUcvEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
@@ -10750,7 +10804,7 @@
         <element href="TapiStreamingGnmi.uml#_CfYvcN2UEeyisriSvKT5Lw"/>
       </children>
       <element href="TapiStreamingGnmi.uml#_CfYvcN2UEeyisriSvKT5Lw"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_jU4Gh0cvEe6bIJjw8ZnZGQ" x="20" y="440" width="141" height="21"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_jU4Gh0cvEe6bIJjw8ZnZGQ" x="-260" y="440" width="181" height="21"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_jU4GiEcvEe6bIJjw8ZnZGQ" type="Comment_Shape" fontName="Segoe UI" fontHeight="6" fillColor="10265827">
       <eAnnotations xmi:id="_jU4GiUcvEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
@@ -10760,7 +10814,7 @@
       </eAnnotations>
       <children xsi:type="notation:DecorationNode" xmi:id="_jU4GjUcvEe6bIJjw8ZnZGQ" type="Comment_BodyLabel"/>
       <element href="TapiStreamingGnmi.uml#_pKsXgEZ4Ee6bIJjw8ZnZGQ"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_jU4GjkcvEe6bIJjw8ZnZGQ" x="20" y="520" width="141" height="21"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_jU4GjkcvEe6bIJjw8ZnZGQ" x="-260" y="520" width="181" height="21"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_jU4Gj0cvEe6bIJjw8ZnZGQ" type="Comment_Shape" fontName="Segoe UI" fontHeight="6" fillColor="8905185">
       <eAnnotations xmi:id="_jU4GkEcvEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
@@ -10773,7 +10827,7 @@
         <element href="TapiStreamingGnmi.uml#_a-WOIN2TEeyisriSvKT5Lw"/>
       </children>
       <element href="TapiStreamingGnmi.uml#_a-WOIN2TEeyisriSvKT5Lw"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_jU4GlkcvEe6bIJjw8ZnZGQ" x="20" y="480" width="141" height="21"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_jU4GlkcvEe6bIJjw8ZnZGQ" x="-260" y="480" width="181" height="21"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_jjNGoFIVEe6m_d6KGfEFwg" type="Class_Shape" fontName="Segoe UI" fontHeight="6" fillColor="12621752">
       <eAnnotations xmi:id="_jjNGoVIVEe6m_d6KGfEFwg" source="PapyrusCSSForceValue">
@@ -11009,23 +11063,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="_jjNIyFIVEe6m_d6KGfEFwg"/>
       </children>
       <element href="TapiStreamingGnmi.uml#_KRgyMFIQEe6m_d6KGfEFwg"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_jjNI8lIVEe6m_d6KGfEFwg" x="440" y="160" width="381" height="201"/>
-    </children>
-    <children xsi:type="notation:Shape" xmi:id="_lN2UMFefEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_lN2UMVefEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_lN2UM1efEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
-        <eObjectValue href="TapiStreamingGnmi.uml#_406Q8KFhEe2n-fmfRwdlPg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_lN2UMlefEe6mE7NoRC7Zaw" x="640" y="60"/>
-    </children>
-    <children xsi:type="notation:Shape" xmi:id="_lOFkwFefEe6mE7NoRC7Zaw" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_lOFkwVefEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_lOFkw1efEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
-        <eObjectValue href="TapiStreamingGnmi.uml#_KRgyMFIQEe6m_d6KGfEFwg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_lOFkwlefEe6mE7NoRC7Zaw" x="640" y="160"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_jjNI8lIVEe6m_d6KGfEFwg" x="360" y="160" width="541" height="201"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_EiusYFegEe6mE7NoRC7Zaw" type="DataType_Shape" fontName="Segoe UI" fontHeight="6" fillColor="10265827">
       <eAnnotations xmi:id="_LSjaYlegEe6mE7NoRC7Zaw" source="PapyrusCSSForceValue">
@@ -11068,7 +11106,23 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="_EivTfFegEe6mE7NoRC7Zaw"/>
       </children>
       <element href="TapiCommon.uml#_6efrYNnVEeWIOYiRCk5bbQ"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_EiusYVegEe6mE7NoRC7Zaw" x="1200" y="40" width="166" height="83"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_EiusYVegEe6mE7NoRC7Zaw" x="1460" y="40" width="241" height="83"/>
+    </children>
+    <children xsi:type="notation:Shape" xmi:id="_wZRMg2aBEe6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_wZRMhGaBEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_wZRMhmaBEe6bwd8NmC1HOg" name="BASE_ELEMENT">
+        <eObjectValue href="TapiStreamingGnmi.uml#_406Q8KFhEe2n-fmfRwdlPg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_wZRMhWaBEe6bwd8NmC1HOg" x="640" y="40"/>
+    </children>
+    <children xsi:type="notation:Shape" xmi:id="_wZjgZ2aBEe6bwd8NmC1HOg" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_wZjgaGaBEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_wZjgamaBEe6bwd8NmC1HOg" name="BASE_ELEMENT">
+        <eObjectValue href="TapiStreamingGnmi.uml#_KRgyMFIQEe6m_d6KGfEFwg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_wZjgaWaBEe6bwd8NmC1HOg" x="640" y="160"/>
     </children>
     <styles xsi:type="notation:StringValueStyle" xmi:id="_c-ZM8UcsEe6bIJjw8ZnZGQ" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xsi:type="notation:DiagramStyle" xmi:id="_c-ZM8kcsEe6bIJjw8ZnZGQ"/>
@@ -11102,9 +11156,9 @@
       </children>
       <styles xsi:type="notation:FontStyle" xmi:id="_oGZKMUcuEe6bIJjw8ZnZGQ"/>
       <element href="TapiStreamingGnmi.uml#_oGYjIEcuEe6bIJjw8ZnZGQ"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_oGZKMkcuEe6bIJjw8ZnZGQ" points="[80, 221, -643984, -643984]$[80, 240, -643984, -643984]"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_oGZKMkcuEe6bIJjw8ZnZGQ" points="[-180, 221, -643984, -643984]$[-180, 240, -643984, -643984]"/>
       <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_oIOWMEcuEe6bIJjw8ZnZGQ" id="(0.23460410557184752,1.0)"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_oIOWMUcuEe6bIJjw8ZnZGQ" id="(0.4419889502762431,0.0)"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_oIOWMUcuEe6bIJjw8ZnZGQ" id="(0.4149377593360996,0.0)"/>
     </edges>
     <edges xsi:type="notation:Connector" xmi:id="_rvpv4EcuEe6bIJjw8ZnZGQ" type="Usage_Edge" source="_jjNGoFIVEe6m_d6KGfEFwg" target="__k34wEcsEe6bIJjw8ZnZGQ">
       <children xsi:type="notation:DecorationNode" xmi:id="_rvpv40cuEe6bIJjw8ZnZGQ" type="Usage_NameLabel">
@@ -11119,7 +11173,7 @@
       <element href="TapiStreamingGnmi.uml#_rvpI0EcuEe6bIJjw8ZnZGQ"/>
       <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_rvpv4kcuEe6bIJjw8ZnZGQ" points="[460, 361, -643984, -643984]$[360, 240, -643984, -643984]"/>
       <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_rxp7AEcuEe6bIJjw8ZnZGQ" id="(0.0,0.7960199004975125)"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_rxp7AUcuEe6bIJjw8ZnZGQ" id="(1.0,0.39603960396039606)"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_rxp7AUcuEe6bIJjw8ZnZGQ" id="(1.0,0.49586776859504134)"/>
     </edges>
     <edges xsi:type="notation:Connector" xmi:id="_toe5wEcuEe6bIJjw8ZnZGQ" type="Usage_Edge" source="_jjNGoFIVEe6m_d6KGfEFwg" target="__k3RsEcsEe6bIJjw8ZnZGQ">
       <children xsi:type="notation:DecorationNode" xmi:id="_toe5w0cuEe6bIJjw8ZnZGQ" type="Usage_NameLabel">
@@ -11179,13 +11233,15 @@
       <element href="TapiStreamingGnmi.uml#_zdxSIEcuEe6bIJjw8ZnZGQ"/>
       <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_zdx5MkcuEe6bIJjw8ZnZGQ" points="[600, 361, -643984, -643984]$[520, 640, -643984, -643984]"/>
       <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_zgGNYEcuEe6bIJjw8ZnZGQ" id="(0.7349081364829396,1.0)"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_zgGNYUcuEe6bIJjw8ZnZGQ" id="(0.36199095022624433,0.0)"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_zgGNYUcuEe6bIJjw8ZnZGQ" id="(0.39867109634551495,0.0)"/>
     </edges>
     <edges xsi:type="notation:Connector" xmi:id="_BW4x0VIWEe6m_d6KGfEFwg" type="Usage_Edge" source="_jjNGoFIVEe6m_d6KGfEFwg" target="__k01cEcsEe6bIJjw8ZnZGQ">
       <children xsi:type="notation:DecorationNode" xmi:id="_BW4x1FIWEe6m_d6KGfEFwg" type="Usage_NameLabel">
+        <styles xsi:type="notation:BooleanValueStyle" xmi:id="_1hEz0GaBEe6bwd8NmC1HOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xsi:type="notation:Location" xmi:id="_BW4x1VIWEe6m_d6KGfEFwg" y="40"/>
       </children>
       <children xsi:type="notation:DecorationNode" xmi:id="_BW4x1lIWEe6m_d6KGfEFwg" type="Usage_StereotypeLabel">
+        <styles xsi:type="notation:BooleanValueStyle" xmi:id="_1pUw4GaBEe6bwd8NmC1HOg" name="IS_UPDATED_POSITION" booleanValue="true"/>
         <layoutConstraint xsi:type="notation:Location" xmi:id="_BW4x11IWEe6m_d6KGfEFwg" x="-5" y="13"/>
       </children>
       <styles xsi:type="notation:FontStyle" xmi:id="_BW4x0lIWEe6m_d6KGfEFwg"/>
@@ -11193,26 +11249,6 @@
       <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_BW4x01IWEe6m_d6KGfEFwg" points="[460, 160, -643984, -643984]$[341, 160, -643984, -643984]"/>
       <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_BnkSIFIWEe6m_d6KGfEFwg" id="(0.0,0.09950248756218906)"/>
       <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_BnkSIVIWEe6m_d6KGfEFwg" id="(1.0,0.8695652173913043)"/>
-    </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_lN2UNFefEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="__k35FUcsEe6bIJjw8ZnZGQ" target="_lN2UMFefEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_lN2UNVefEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_lN2UOVefEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
-        <eObjectValue href="TapiStreamingGnmi.uml#_406Q8KFhEe2n-fmfRwdlPg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_lN2UNlefEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_lN2UN1efEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_lN2UOFefEe6mE7NoRC7Zaw"/>
-    </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_lOFkxFefEe6mE7NoRC7Zaw" type="StereotypeCommentLink" source="_jjNGoFIVEe6m_d6KGfEFwg" target="_lOFkwFefEe6mE7NoRC7Zaw">
-      <styles xsi:type="notation:FontStyle" xmi:id="_lOFkxVefEe6mE7NoRC7Zaw"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_lOFkyVefEe6mE7NoRC7Zaw" name="BASE_ELEMENT">
-        <eObjectValue href="TapiStreamingGnmi.uml#_KRgyMFIQEe6m_d6KGfEFwg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_lOFkxlefEe6mE7NoRC7Zaw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_lOFkx1efEe6mE7NoRC7Zaw"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_lOFkyFefEe6mE7NoRC7Zaw"/>
     </edges>
     <edges xsi:type="notation:Connector" xmi:id="_YDLNMFegEe6mE7NoRC7Zaw" type="Usage_Edge" source="__k35FUcsEe6bIJjw8ZnZGQ" target="_EiusYFegEe6mE7NoRC7Zaw">
       <children xsi:type="notation:DecorationNode" xmi:id="_YDLNM1egEe6mE7NoRC7Zaw" type="Usage_NameLabel">
@@ -11228,6 +11264,26 @@
       <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_YDLNMlegEe6mE7NoRC7Zaw" points="[821, 100, -643984, -643984]$[1060, 100, -643984, -643984]"/>
       <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_YUql0FegEe6mE7NoRC7Zaw" id="(1.0,0.39603960396039606)"/>
       <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_YUql0VegEe6mE7NoRC7Zaw" id="(0.0,0.4819277108433735)"/>
+    </edges>
+    <edges xsi:type="notation:Connector" xmi:id="_wZRMh2aBEe6bwd8NmC1HOg" type="StereotypeCommentLink" source="__k35FUcsEe6bIJjw8ZnZGQ" target="_wZRMg2aBEe6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_wZRMiGaBEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_wZRMjGaBEe6bwd8NmC1HOg" name="BASE_ELEMENT">
+        <eObjectValue href="TapiStreamingGnmi.uml#_406Q8KFhEe2n-fmfRwdlPg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_wZRMiWaBEe6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_wZRMimaBEe6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_wZRMi2aBEe6bwd8NmC1HOg"/>
+    </edges>
+    <edges xsi:type="notation:Connector" xmi:id="_wZjga2aBEe6bwd8NmC1HOg" type="StereotypeCommentLink" source="_jjNGoFIVEe6m_d6KGfEFwg" target="_wZjgZ2aBEe6bwd8NmC1HOg">
+      <styles xsi:type="notation:FontStyle" xmi:id="_wZjgbGaBEe6bwd8NmC1HOg"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_wZjgcGaBEe6bwd8NmC1HOg" name="BASE_ELEMENT">
+        <eObjectValue href="TapiStreamingGnmi.uml#_KRgyMFIQEe6m_d6KGfEFwg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_wZjgbWaBEe6bwd8NmC1HOg" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_wZjgbmaBEe6bwd8NmC1HOg"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_wZjgb2aBEe6bwd8NmC1HOg"/>
     </edges>
   </notation:Diagram>
 </xmi:XMI>


### PR DESCRIPTION
Diagrams were constructed with Windows set to 100%.

For gendoc generation I have viewed the diagrams at 150% and have resized as necessary.

This is caused by an issue in Papyrus.