### PR TITLE
Corrected gNMI enumeration defaults (and other minor improvements)

### DIFF
--- a/UML/TapiGnmiStreaming.notation
+++ b/UML/TapiGnmiStreaming.notation
@@ -63,6 +63,24 @@
         <layoutConstraint xsi:type="notation:Location" xmi:id="_kiEsO7HDEe2tjo53LmkUFA" y="15"/>
       </children>
       <children xsi:type="notation:BasicCompartment" xmi:id="_kiEsPLHDEe2tjo53LmkUFA" type="Enumeration_LiteralCompartment">
+        <children xsi:type="notation:Shape" xmi:id="_Eu-ZMHfMEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_WHrKYHfMEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_WHrKYXfMEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_WHrxcHfMEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_WHrxcXfMEe6iN6ao8wePZw" key="fontColor" value="true"/>
+          </eAnnotations>
+          <children xsi:type="notation:BasicCompartment" xmi:id="_FBJHQHfMEe6iN6ao8wePZw" type="StereotypeBrace">
+            <eAnnotations xmi:id="_ZEGfQHfMEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+              <details xmi:id="_ZEGfQXfMEe6iN6ao8wePZw" key="visible" value="true"/>
+            </eAnnotations>
+            <styles xsi:type="notation:TitleStyle" xmi:id="_FBJHQXfMEe6iN6ao8wePZw"/>
+            <styles xsi:type="notation:StringValueStyle" xmi:id="_FBJHQnfMEe6iN6ao8wePZw" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
+            <element href="UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_6vylQKZvEe2n-fmfRwdlPg"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_FBJHQ3fMEe6iN6ao8wePZw"/>
+          </children>
+          <element href="TapiGnmiStreaming.uml#_lH_CwHcaEe6iN6ao8wePZw"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_Eu-ZMXfMEe6iN6ao8wePZw"/>
+        </children>
         <children xsi:type="notation:Shape" xmi:id="_kiEsPbHDEe2tjo53LmkUFA" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
           <eAnnotations xmi:id="_kiEsPrHDEe2tjo53LmkUFA" source="PapyrusCSSForceValue">
             <details xmi:id="_kiEsP7HDEe2tjo53LmkUFA" key="bold" value="true"/>
@@ -142,7 +160,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="_kiEshLHDEe2tjo53LmkUFA"/>
       </children>
       <element href="TapiGnmiStreaming.uml#_nwJQkKYQEe2n-fmfRwdlPg"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_kiEsiLHDEe2tjo53LmkUFA" x="20" y="160" width="241" height="121"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_kiEsiLHDEe2tjo53LmkUFA" x="20" y="100" width="241" height="141"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_kiGhULHDEe2tjo53LmkUFA" type="Enumeration_Shape" fontName="Segoe UI" fontHeight="6" fillColor="8905185">
       <eAnnotations xmi:id="_kiGhUbHDEe2tjo53LmkUFA" source="PapyrusCSSForceValue">
@@ -498,7 +516,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="_kiHJFLHDEe2tjo53LmkUFA"/>
       </children>
       <element href="TapiGnmiStreaming.uml#_tGy2YKJFEe2n-fmfRwdlPg"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_kiHJGLHDEe2tjo53LmkUFA" x="20" y="-40" width="341" height="141"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_kiHJGLHDEe2tjo53LmkUFA" x="20" y="-80" width="341" height="141"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_kiHvfrHDEe2tjo53LmkUFA" type="Enumeration_Shape" fontName="Segoe UI" fontHeight="6" fillColor="8905185">
       <eAnnotations xmi:id="_kiHvf7HDEe2tjo53LmkUFA" source="PapyrusCSSForceValue">
@@ -514,6 +532,24 @@
         <layoutConstraint xsi:type="notation:Location" xmi:id="_kiHvhbHDEe2tjo53LmkUFA" y="15"/>
       </children>
       <children xsi:type="notation:BasicCompartment" xmi:id="_kiHvhrHDEe2tjo53LmkUFA" type="Enumeration_LiteralCompartment">
+        <children xsi:type="notation:Shape" xmi:id="_0Xc7sHfMEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_Cnn1sHfNEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_Cnn1sXfNEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_CnocwHfNEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_CnpD0HfNEe6iN6ao8wePZw" key="fontColor" value="true"/>
+          </eAnnotations>
+          <children xsi:type="notation:BasicCompartment" xmi:id="_0rVhA3fMEe6iN6ao8wePZw" type="StereotypeBrace">
+            <eAnnotations xmi:id="_4c8xcHfMEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+              <details xmi:id="_4c8xcXfMEe6iN6ao8wePZw" key="visible" value="true"/>
+            </eAnnotations>
+            <styles xsi:type="notation:TitleStyle" xmi:id="_0rVhBHfMEe6iN6ao8wePZw"/>
+            <styles xsi:type="notation:StringValueStyle" xmi:id="_0rVhBXfMEe6iN6ao8wePZw" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
+            <element href="UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_6vylQKZvEe2n-fmfRwdlPg"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_0rVhBnfMEe6iN6ao8wePZw"/>
+          </children>
+          <element href="TapiGnmiStreaming.uml#_Gux9wHccEe6iN6ao8wePZw"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_0Xc7sXfMEe6iN6ao8wePZw"/>
+        </children>
         <children xsi:type="notation:Shape" xmi:id="_kiHvh7HDEe2tjo53LmkUFA" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
           <eAnnotations xmi:id="_kiHviLHDEe2tjo53LmkUFA" source="PapyrusCSSForceValue">
             <details xmi:id="_kiHvibHDEe2tjo53LmkUFA" key="bold" value="true"/>
@@ -593,7 +629,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="_kiHvzrHDEe2tjo53LmkUFA"/>
       </children>
       <element href="TapiGnmiStreaming.uml#_OSJcgKZuEe2n-fmfRwdlPg"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_kiHv0rHDEe2tjo53LmkUFA" x="20" y="320" width="241" height="121"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_kiHv0rHDEe2tjo53LmkUFA" x="20" y="280" width="241" height="141"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_kiHv07HDEe2tjo53LmkUFA" type="Enumeration_Shape" fontName="Segoe UI" fontHeight="6" fillColor="8905185">
       <eAnnotations xmi:id="_kiHv1LHDEe2tjo53LmkUFA" source="PapyrusCSSForceValue">
@@ -2335,230 +2371,266 @@
         <layoutConstraint xsi:type="notation:Location" xmi:id="_7wqpkkZ3Ee6bIJjw8ZnZGQ" y="15"/>
       </children>
       <children xsi:type="notation:BasicCompartment" xmi:id="_7wqpk0Z3Ee6bIJjw8ZnZGQ" type="Enumeration_LiteralCompartment">
-        <children xsi:type="notation:Shape" xmi:id="_AJBJ4EZ4Ee6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="_Nl2iekZ4Ee6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="_Nl2ie0Z4Ee6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="_Nl3JjEZ4Ee6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="_Nl4Xp0Z4Ee6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_HyKgkHfQEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_Sd1ZEHfQEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_Sd1ZEXfQEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_Sd_xInfQEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_SeF3wHfQEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
           <element href="TapiCommon.uml#_-gM0AEyXEe2yGsF8121Sxw"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="_AJBw8EZ4Ee6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_HyKgkXfQEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="_AJCYAEZ4Ee6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="_Nl2idkZ4Ee6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="_Nl2id0Z4Ee6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="_Nl3JikZ4Ee6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="_Nl4XpUZ4Ee6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_HyMVwHfQEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_Sd2AIHfQEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_Sd2AIXfQEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_SeAYMHfQEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_SeF3wXfQEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
           <element href="TapiCommon.uml#_f5RJMJUgEe2x3INiJyRnZg"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="_AJCYAUZ4Ee6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_HyMVwXfQEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="_AJCYAkZ4Ee6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="_Nl2ieEZ4Ee6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="_Nl2ieUZ4Ee6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="_Nl3Ji0Z4Ee6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="_Nl4XpkZ4Ee6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_HyM80HfQEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_Sd2nMHfQEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_Sd2nMXfQEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_SeAYMXfQEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_SeF3wnfQEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
           <element href="TapiCommon.uml#_-gThsEyXEe2yGsF8121Sxw"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="_AJCYA0Z4Ee6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_HyM80XfQEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="_AJCYBEZ4Ee6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="_Nl2idEZ4Ee6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="_Nl2idUZ4Ee6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="_Nl3JiUZ4Ee6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="_Nl4XpEZ4Ee6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_HyM80nfQEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_Sd2nMnfQEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_Sd2nM3fQEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_SeA_QHfQEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_SeGe0HfQEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
           <element href="TapiCommon.uml#_n3Bp8JUgEe2x3INiJyRnZg"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="_AJCYBUZ4Ee6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_HyM803fQEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="_AJC_EEZ4Ee6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="_Nl2ickZ4Ee6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="_Nl2ic0Z4Ee6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="_Nl3JiEZ4Ee6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="_Nl4Xo0Z4Ee6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_HyNj4HfQEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_Sd2nNHfQEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_Sd2nNXfQEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_SeA_QXfQEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_SeGe0XfQEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
           <element href="TapiCommon.uml#_YK5UACyZEe6nUqp56BHaLA"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="_AJC_EUZ4Ee6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_HyNj4XfQEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="_AJC_EkZ4Ee6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="_Nl2icEZ4Ee6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="_Nl2icUZ4Ee6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="_Nl3Jh0Z4Ee6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="_Nl4XokZ4Ee6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_HyNj4nfQEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_Sd3OQHfQEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_Sd3OQXfQEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_SeA_QnfQEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_SeGe0nfQEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
           <element href="TapiCommon.uml#_zE4OMCyZEe6nUqp56BHaLA"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="_AJC_E0Z4Ee6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_HyNj43fQEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="_AJC_FEZ4Ee6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="_Nl1UY0Z4Ee6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="_Nl1UZEZ4Ee6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="_Nl3JhkZ4Ee6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="_Nl4XoUZ4Ee6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_HyOK8HfQEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_Sd3OQnfQEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_Sd31UHfQEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_SeBmUHfQEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_SeGe03fQEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
           <element href="TapiCommon.uml#_QpLrgCyYEe6nUqp56BHaLA"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="_AJC_FUZ4Ee6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_HyOK8XfQEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="_AJDmIEZ4Ee6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="_Nl1UYUZ4Ee6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="_Nl1UYkZ4Ee6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="_Nl3JhUZ4Ee6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="_Nl4XoEZ4Ee6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_HyOyAHfQEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_Sd31UXfQEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_Sd31UnfQEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_SeBmUXfQEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_SeGe1HfQEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
           <element href="TapiCommon.uml#_8GIowCyYEe6nUqp56BHaLA"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="_AJDmIUZ4Ee6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_HyOyAXfQEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="_AJDmIkZ4Ee6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="_Nl1UX0Z4Ee6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="_Nl1UYEZ4Ee6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="_Nl3JhEZ4Ee6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="_Nl3woEZ4Ee6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_HyOyAnfQEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_Sd31U3fQEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_Sd4cYHfQEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_SeBmUnfQEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_SeHF4HfQEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
           <element href="TapiCommon.uml#_-gVW4EyXEe2yGsF8121Sxw"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="_AJDmI0Z4Ee6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_HyOyA3fQEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="_AJDmJEZ4Ee6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="_Nl1UW0Z4Ee6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="_Nl1UXEZ4Ee6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="_Nl3JgkZ4Ee6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="_Nl3wnkZ4Ee6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_HyQAIHfQEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_Sd4cYXfQEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_Sd5DcHfQEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_SeCNYHfQEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_SeHF4XfQEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
           <element href="TapiCommon.uml#_3KWgsCyXEe6nUqp56BHaLA"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="_AJDmJUZ4Ee6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_HyQAIXfQEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="_AJDmJkZ4Ee6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="_Nl1UXUZ4Ee6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="_Nl1UXkZ4Ee6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="_Nl3Jg0Z4Ee6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="_Nl3wn0Z4Ee6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_HyQnMHfQEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_Sd5DcXfQEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_Sd5DcnfQEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_SeCNYXfQEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_SeHs8HfQEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
           <element href="TapiCommon.uml#_UprCQCyUEe6nUqp56BHaLA"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="_AJDmJ0Z4Ee6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_HyQnMXfQEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="_AJENMEZ4Ee6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="_Nl1UWUZ4Ee6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="_Nl1UWkZ4Ee6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="_Nl3JgUZ4Ee6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="_Nl3wnUZ4Ee6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_HyROQHfQEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_Sd5qgHfQEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_Sd5qgXfQEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_SeCNYnfQEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_SeHs8XfQEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
           <element href="TapiCommon.uml#_mbkZwCyYEe6nUqp56BHaLA"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="_AJENMUZ4Ee6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_HyROQXfQEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="_AJENMkZ4Ee6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="_Nl1UV0Z4Ee6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="_Nl1UWEZ4Ee6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="_Nl3JgEZ4Ee6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="_Nl3wnEZ4Ee6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_HyR1UHfQEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_Sd5qgnfQEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_Sd5qg3fQEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_SeC0cHfQEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_SeIUAHfQEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
           <element href="TapiCommon.uml#_-WsyoCyXEe6nUqp56BHaLA"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="_AJENM0Z4Ee6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_HyR1UXfQEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="_AJENNEZ4Ee6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="_Nl1UVUZ4Ee6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="_Nl1UVkZ4Ee6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="_Nl2iiEZ4Ee6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="_Nl3wm0Z4Ee6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_HyScYHfQEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_Sd5qhHfQEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_Sd6RkHfQEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_SeC0cXfQEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_SeIUAXfQEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
           <element href="TapiCommon.uml#_UxzRQCyZEe6nUqp56BHaLA"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="_AJENNUZ4Ee6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_HyScYXfQEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="_AJENNkZ4Ee6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="_Nl1UU0Z4Ee6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="_Nl1UVEZ4Ee6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="_Nl2ih0Z4Ee6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="_Nl3wmkZ4Ee6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_HyTDcHfQEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_Sd6RkXfQEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_Sd6RknfQEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_SeC0cnfQEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_SeI7EHfQEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
           <element href="TapiCommon.uml#_DvsQkCyYEe6nUqp56BHaLA"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="_AJENN0Z4Ee6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_HyTDcXfQEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="_AJE0QEZ4Ee6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="_Nl1UUUZ4Ee6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="_Nl1UUkZ4Ee6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="_Nl2ihkZ4Ee6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="_Nl3wmUZ4Ee6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_HyTqgHfQEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_Sd6Rk3fQEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_Sd6RlHfQEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_SeC0c3fQEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_SeI7EXfQEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
           <element href="TapiCommon.uml#_m2-4gCyaEe6nUqp56BHaLA"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="_AJE0QUZ4Ee6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_HyTqgXfQEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="_AJE0QkZ4Ee6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="_Nl0tTEZ4Ee6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="_Nl1UUEZ4Ee6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="_Nl2ihUZ4Ee6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="_Nl3wmEZ4Ee6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_HyURkHfQEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_Sd64oHfQEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_Sd64oXfQEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_SeC0dHfQEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_SeI7EnfQEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
           <element href="TapiCommon.uml#_yQ0JcCyYEe6nUqp56BHaLA"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="_AJE0Q0Z4Ee6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_HyURkXfQEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="_AJE0REZ4Ee6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="_Nl0tSkZ4Ee6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="_Nl0tS0Z4Ee6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="_Nl2ihEZ4Ee6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="_Nl3wl0Z4Ee6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_HyU4oHfQEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_Sd64onfQEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_Sd64o3fQEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_SeDbgHfQEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_SeJiIHfQEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
           <element href="TapiCommon.uml#_rk0xYJUgEe2x3INiJyRnZg"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="_AJE0RUZ4Ee6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_HyU4oXfQEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="_AJE0RkZ4Ee6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="_Nl0tSEZ4Ee6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="_Nl0tSUZ4Ee6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="_Nl2ig0Z4Ee6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="_Nl3wlkZ4Ee6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_HyVfsHfQEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_Sd64pHfQEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_Sd64pXfQEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_SeDbgXfQEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_SeJiIXfQEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
           <element href="TapiCommon.uml#_L-NsoJKGEe2zcM0SMtXEHg"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="_AJE0R0Z4Ee6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_HyVfsXfQEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="_AJFbUEZ4Ee6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="_Nl0tRkZ4Ee6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="_Nl0tR0Z4Ee6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="_Nl2igkZ4Ee6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="_Nl3wlUZ4Ee6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_HyVfsnfQEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_Sd7fsHfQEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_Sd7fsXfQEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_SeDbgnfQEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_SeKJMHfQEe6iN6ao8wePZw" key="fontColor" value="true"/>
+          </eAnnotations>
+          <element href="TapiCommon.uml#_5LiwwENeEe6kK8KhUj-djw"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_HyVfs3fQEe6iN6ao8wePZw"/>
+        </children>
+        <children xsi:type="notation:Shape" xmi:id="_HyWGwHfQEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_Sd8GwHfQEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_Sd8GwXfQEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_SeDbg3fQEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_SeKJMXfQEe6iN6ao8wePZw" key="fontColor" value="true"/>
+          </eAnnotations>
+          <element href="TapiCommon.uml#_6y4iAENeEe6kK8KhUj-djw"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_HyWGwXfQEe6iN6ao8wePZw"/>
+        </children>
+        <children xsi:type="notation:Shape" xmi:id="_HyWGwnfQEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_Sd8GwnfQEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_Sd8Gw3fQEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_SeDbhHfQEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_SeKwQHfQEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
           <element href="TapiCommon.uml#_KAe0oJKGEe2zcM0SMtXEHg"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="_AJFbUUZ4Ee6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_HyWGw3fQEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="_AJFbUkZ4Ee6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="_Nl0tREZ4Ee6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="_Nl0tRUZ4Ee6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="_Nl2igUZ4Ee6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="_Nl3wlEZ4Ee6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_HyWt0HfQEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_Sd8t0HfQEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_Sd8t0XfQEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_SeECkHfQEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_SeKwQXfQEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
           <element href="TapiCommon.uml#_E9UjUJUkEe2x3INiJyRnZg"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="_AJFbU0Z4Ee6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_HyWt0XfQEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="_AJFbVEZ4Ee6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="_Nl0tQkZ4Ee6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="_Nl0tQ0Z4Ee6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="_Nl2igEZ4Ee6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="_Nl3wk0Z4Ee6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_HyWt0nfQEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_Sd8t0nfQEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_Sd9U4HfQEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_SeECkXfQEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_SeKwQnfQEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
           <element href="TapiCommon.uml#_OAnCMJKGEe2zcM0SMtXEHg"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="_AJFbVUZ4Ee6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_HyWt03fQEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="_AJFbVkZ4Ee6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="_Nl0tQEZ4Ee6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="_Nl0tQUZ4Ee6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="_Nl2if0Z4Ee6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="_Nl3wkkZ4Ee6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_HyXU4HfQEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_Sd9U4XfQEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_Sd9U4nfQEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_SeECknfQEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_SeLXUHfQEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
           <element href="TapiCommon.uml#_c9kNEJUgEe2x3INiJyRnZg"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="_AJFbV0Z4Ee6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_HyXU4XfQEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="_AJGCYEZ4Ee6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="_Nl0GNEZ4Ee6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="_Nl0GNUZ4Ee6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="_Nl2ifkZ4Ee6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="_Nl3wkUZ4Ee6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_HyXU4nfQEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_Sd9U43fQEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_Sd9U5HfQEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_SeECk3fQEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_SeLXUXfQEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
           <element href="TapiCommon.uml#_-gWlAEyXEe2yGsF8121Sxw"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="_AJGCYUZ4Ee6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_HyXU43fQEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="_AJGCYkZ4Ee6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="_Nl0GMkZ4Ee6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="_Nl0GM0Z4Ee6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="_Nl2ifUZ4Ee6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="_Nl3wkEZ4Ee6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_HyX78HfQEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_Sd978HfQEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_Sd978XfQEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_SeEpoHfQEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_SeLXUnfQEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
           <element href="TapiCommon.uml#_-gbdgEyXEe2yGsF8121Sxw"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="_AJGCY0Z4Ee6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_HyX78XfQEe6iN6ao8wePZw"/>
+        </children>
+        <children xsi:type="notation:Shape" xmi:id="_HyX78nfQEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_Sd_KEHfQEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_Sd_KEXfQEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_SeFQsHfQEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_SeL-YHfQEe6iN6ao8wePZw" key="fontColor" value="true"/>
+          </eAnnotations>
+          <element href="TapiCommon.uml#_F11SEENfEe6kK8KhUj-djw"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_HyX783fQEe6iN6ao8wePZw"/>
+        </children>
+        <children xsi:type="notation:Shape" xmi:id="_HyYjAHfQEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_Sd_xIHfQEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_Sd_xIXfQEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_SeFQsXfQEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_SeL-YXfQEe6iN6ao8wePZw" key="fontColor" value="true"/>
+          </eAnnotations>
+          <element href="TapiCommon.uml#_HfleIENfEe6kK8KhUj-djw"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_HyYjAXfQEe6iN6ao8wePZw"/>
         </children>
         <styles xsi:type="notation:TitleStyle" xmi:id="_7wqplEZ3Ee6bIJjw8ZnZGQ"/>
         <styles xsi:type="notation:SortingStyle" xmi:id="_7wqplUZ3Ee6bIJjw8ZnZGQ"/>
@@ -2566,7 +2638,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="_7wqpl0Z3Ee6bIJjw8ZnZGQ"/>
       </children>
       <element href="TapiCommon.uml#_xnfcMEyXEe2yGsF8121Sxw"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_7wo0YUZ3Ee6bIJjw8ZnZGQ" x="1560" y="-260" width="241" height="441"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_7wo0YUZ3Ee6bIJjw8ZnZGQ" x="1560" y="-420" width="241" height="601"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_pKuzwEZ4Ee6bIJjw8ZnZGQ" type="Comment_Shape" fontName="Segoe UI" fontHeight="6" fillColor="10265827">
       <eAnnotations xmi:id="_s7UJcEZ4Ee6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
@@ -2589,6 +2661,24 @@
         <layoutConstraint xsi:type="notation:Location" xmi:id="_nDV090cyEe6bIJjw8ZnZGQ" y="15"/>
       </children>
       <children xsi:type="notation:BasicCompartment" xmi:id="_nDV0-EcyEe6bIJjw8ZnZGQ" type="Enumeration_LiteralCompartment">
+        <children xsi:type="notation:Shape" xmi:id="_aO_voHfNEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_jqDU0HfNEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_jqDU0XfNEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_jqD74nfNEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_jqEi8XfNEe6iN6ao8wePZw" key="fontColor" value="true"/>
+          </eAnnotations>
+          <children xsi:type="notation:BasicCompartment" xmi:id="_bT47IHfNEe6iN6ao8wePZw" type="StereotypeBrace">
+            <eAnnotations xmi:id="_d1CCMHfNEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+              <details xmi:id="_d1CpQHfNEe6iN6ao8wePZw" key="visible" value="true"/>
+            </eAnnotations>
+            <styles xsi:type="notation:TitleStyle" xmi:id="_bT5iMHfNEe6iN6ao8wePZw"/>
+            <styles xsi:type="notation:StringValueStyle" xmi:id="_bT5iMXfNEe6iN6ao8wePZw" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
+            <element href="UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_6vylQKZvEe2n-fmfRwdlPg"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_bT5iMnfNEe6iN6ao8wePZw"/>
+          </children>
+          <element href="TapiGnmiStreaming.uml#_RpcNIHcfEe6iN6ao8wePZw"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_aO_voXfNEe6iN6ao8wePZw"/>
+        </children>
         <children xsi:type="notation:Shape" xmi:id="_nDV0-UcyEe6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
           <eAnnotations xmi:id="_nDV0-kcyEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
             <details xmi:id="_nDV0-0cyEe6bIJjw8ZnZGQ" key="bold" value="true"/>
@@ -2967,6 +3057,42 @@
           <element href="TapiGnmiStreaming.uml#__6_sJUcnEe6bIJjw8ZnZGQ"/>
           <layoutConstraint xsi:type="notation:Location" xmi:id="_nDV2XUcyEe6bIJjw8ZnZGQ"/>
         </children>
+        <children xsi:type="notation:Shape" xmi:id="_cBsU8HfQEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_sIrmoHfQEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_sIrmoXfQEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_sIrmpHfQEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_sIs0wHfQEe6iN6ao8wePZw" key="fontColor" value="true"/>
+          </eAnnotations>
+          <children xsi:type="notation:BasicCompartment" xmi:id="_yrt10HfQEe6iN6ao8wePZw" type="StereotypeBrace">
+            <eAnnotations xmi:id="_-z3TYHfQEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+              <details xmi:id="_-z3TYXfQEe6iN6ao8wePZw" key="visible" value="true"/>
+            </eAnnotations>
+            <styles xsi:type="notation:TitleStyle" xmi:id="_yrt10XfQEe6iN6ao8wePZw"/>
+            <styles xsi:type="notation:StringValueStyle" xmi:id="_yrt10nfQEe6iN6ao8wePZw" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
+            <element href="UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_6vylQKZvEe2n-fmfRwdlPg"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_yrt103fQEe6iN6ao8wePZw"/>
+          </children>
+          <element href="TapiGnmiStreaming.uml#_aTg74HfQEe6iN6ao8wePZw"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_cBsU8XfQEe6iN6ao8wePZw"/>
+        </children>
+        <children xsi:type="notation:Shape" xmi:id="_fNSHMHfQEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_sIrmonfQEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_sIrmo3fQEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_sIrmpXfQEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_sIs0wXfQEe6iN6ao8wePZw" key="fontColor" value="true"/>
+          </eAnnotations>
+          <children xsi:type="notation:BasicCompartment" xmi:id="_3GJZwHfQEe6iN6ao8wePZw" type="StereotypeBrace">
+            <eAnnotations xmi:id="_9sYt8HfQEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+              <details xmi:id="_9sYt8XfQEe6iN6ao8wePZw" key="visible" value="true"/>
+            </eAnnotations>
+            <styles xsi:type="notation:TitleStyle" xmi:id="_3GJZwXfQEe6iN6ao8wePZw"/>
+            <styles xsi:type="notation:StringValueStyle" xmi:id="_3GJZwnfQEe6iN6ao8wePZw" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
+            <element href="UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_6vylQKZvEe2n-fmfRwdlPg"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_3GJZw3fQEe6iN6ao8wePZw"/>
+          </children>
+          <element href="TapiGnmiStreaming.uml#_dmUwcHfQEe6iN6ao8wePZw"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_fNSHMXfQEe6iN6ao8wePZw"/>
+        </children>
         <children xsi:type="notation:Shape" xmi:id="_nDV2XkcyEe6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
           <eAnnotations xmi:id="_nDV2X0cyEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
             <details xmi:id="_nDV2YEcyEe6bIJjw8ZnZGQ" key="bold" value="true"/>
@@ -3039,13 +3165,49 @@
           <element href="TapiGnmiStreaming.uml#__6_sKkcnEe6bIJjw8ZnZGQ"/>
           <layoutConstraint xsi:type="notation:Location" xmi:id="_nDV2oUcyEe6bIJjw8ZnZGQ"/>
         </children>
+        <children xsi:type="notation:Shape" xmi:id="_aPBk0HfNEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_jqDU0nfNEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_jqDU03fNEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_jqD743fNEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_jqEi8nfNEe6iN6ao8wePZw" key="fontColor" value="true"/>
+          </eAnnotations>
+          <children xsi:type="notation:BasicCompartment" xmi:id="_bT_BwHfNEe6iN6ao8wePZw" type="StereotypeBrace">
+            <eAnnotations xmi:id="_fEyZ4HfNEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+              <details xmi:id="_fEyZ4XfNEe6iN6ao8wePZw" key="visible" value="true"/>
+            </eAnnotations>
+            <styles xsi:type="notation:TitleStyle" xmi:id="_bT_BwXfNEe6iN6ao8wePZw"/>
+            <styles xsi:type="notation:StringValueStyle" xmi:id="_bT_BwnfNEe6iN6ao8wePZw" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
+            <element href="UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_6vylQKZvEe2n-fmfRwdlPg"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_bT_Bw3fNEe6iN6ao8wePZw"/>
+          </children>
+          <element href="TapiGnmiStreaming.uml#_knymIHciEe6iN6ao8wePZw"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_aPBk0XfNEe6iN6ao8wePZw"/>
+        </children>
+        <children xsi:type="notation:Shape" xmi:id="_aPDaAHfNEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_jqD74HfNEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_jqD74XfNEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_jqEi8HfNEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_jqEi83fNEe6iN6ao8wePZw" key="fontColor" value="true"/>
+          </eAnnotations>
+          <children xsi:type="notation:BasicCompartment" xmi:id="_bUEhUHfNEe6iN6ao8wePZw" type="StereotypeBrace">
+            <eAnnotations xmi:id="_gY5GEHfNEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+              <details xmi:id="_gY5GEXfNEe6iN6ao8wePZw" key="visible" value="true"/>
+            </eAnnotations>
+            <styles xsi:type="notation:TitleStyle" xmi:id="_bUEhUXfNEe6iN6ao8wePZw"/>
+            <styles xsi:type="notation:StringValueStyle" xmi:id="_bUEhUnfNEe6iN6ao8wePZw" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
+            <element href="UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_6vylQKZvEe2n-fmfRwdlPg"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_bUEhU3fNEe6iN6ao8wePZw"/>
+          </children>
+          <element href="TapiGnmiStreaming.uml#_sSqnIHciEe6iN6ao8wePZw"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_aPDaAXfNEe6iN6ao8wePZw"/>
+        </children>
         <styles xsi:type="notation:TitleStyle" xmi:id="_nDV2okcyEe6bIJjw8ZnZGQ"/>
         <styles xsi:type="notation:SortingStyle" xmi:id="_nDV2o0cyEe6bIJjw8ZnZGQ"/>
         <styles xsi:type="notation:FilteringStyle" xmi:id="_nDV2pEcyEe6bIJjw8ZnZGQ"/>
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="_nDV2pUcyEe6bIJjw8ZnZGQ"/>
       </children>
       <element href="TapiGnmiStreaming.uml#__6_sAEcnEe6bIJjw8ZnZGQ"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_nDV2qUcyEe6bIJjw8ZnZGQ" x="1140" y="-260" width="381" height="441"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_nDV2qUcyEe6bIJjw8ZnZGQ" x="1140" y="-420" width="381" height="601"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="_KSJrYFIQEe6m_d6KGfEFwg" type="Class_Shape" fontName="Segoe UI" fontHeight="6" fillColor="12621752">
       <eAnnotations xmi:id="_sV5dkFIQEe6m_d6KGfEFwg" source="PapyrusCSSForceValue">
@@ -3511,261 +3673,261 @@
       <element href="TapiGnmiStreaming.uml#_KRgyMFIQEe6m_d6KGfEFwg"/>
       <layoutConstraint xsi:type="notation:Bounds" xmi:id="_KSJrYVIQEe6m_d6KGfEFwg" x="560" y="320" width="581" height="201"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_ruXtIGnCEe6M0MEaxCUWiQ" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_ruXtIWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_ruXtI2nCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_W8UlUHfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_W8UlUXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_W8UlU3fKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_FCwpUKYBEe2n-fmfRwdlPg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_ruXtImnCEe6M0MEaxCUWiQ" x="1600" y="320"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_W8UlUnfKEe6iN6ao8wePZw" x="1600" y="320"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_ruwusGnCEe6M0MEaxCUWiQ" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_ruwusWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_ruxVwGnCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_W83-8HfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_W83-8XfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_W84mAHfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_ZhiA0EOEEe6bIJjw8ZnZGQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_ruwusmnCEe6M0MEaxCUWiQ" x="1600" y="220"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_W83-8nfKEe6iN6ao8wePZw" x="1600" y="220"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_ru3cYGnCEe6M0MEaxCUWiQ" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_ru3cYWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_ru3cY2nCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_W9PLUHfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_W9PLUXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_W9PLU3fKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_VET7gFISEe6m_d6KGfEFwg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_ru3cYmnCEe6M0MEaxCUWiQ" x="1600" y="220"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_W9PLUnfKEe6iN6ao8wePZw" x="1600" y="220"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_rvd5UGnCEe6M0MEaxCUWiQ" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_rvd5UWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_rvd5U2nCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_W-K_cHfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_W-K_cXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_W-LmgHfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiOam.uml#_vnyfgF0IEeipas1p-rFJBA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_rvd5UmnCEe6M0MEaxCUWiQ" x="1700" y="400"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_W-K_cnfKEe6iN6ao8wePZw" x="1700" y="400"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_rxOz4GnCEe6M0MEaxCUWiQ" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_rxOz4WnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_rxOz42nCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_XA4VMHfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_XA4VMXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_XA4VM3fKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_406Q8KFhEe2n-fmfRwdlPg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_rxOz4mnCEe6M0MEaxCUWiQ" x="700" y="580"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_XA4VMnfKEe6iN6ao8wePZw" x="700" y="580"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_ryh0YGnCEe6M0MEaxCUWiQ" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_ryh0YWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_ryh0Y2nCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_XDEtkHfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_XDEtkXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_XDEtk3fKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_Aow5sKFgEe2n-fmfRwdlPg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_ryh0YmnCEe6M0MEaxCUWiQ" x="720" y="180"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_XDEtknfKEe6iN6ao8wePZw" x="720" y="180"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_ry5AwGnCEe6M0MEaxCUWiQ" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_ry5AwWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_ry5Aw2nCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_XDqjcHfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_XDqjcXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_XDrKgHfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_SyXM4KYBEe2n-fmfRwdlPg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_ry5AwmnCEe6M0MEaxCUWiQ" x="720" y="80"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_XDqjcnfKEe6iN6ao8wePZw" x="720" y="80"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_ry_ucGnCEe6M0MEaxCUWiQ" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_ry_ucWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_ry_uc2nCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_XD8QQHfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_XD8QQXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_XD8QQ3fKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#__d9xQEODEe6bIJjw8ZnZGQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_ry_ucmnCEe6M0MEaxCUWiQ" x="720" y="80"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_XD8QQnfKEe6iN6ao8wePZw" x="720" y="80"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_rzGcIGnCEe6M0MEaxCUWiQ" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_rzGcIWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_rzHDMGnCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_XESOgHfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_XESOgXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_XES1kHfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_S1iBsFIQEe6m_d6KGfEFwg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_rzGcImnCEe6M0MEaxCUWiQ" x="720" y="80"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_XESOgnfKEe6iN6ao8wePZw" x="720" y="80"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_rzZXEGnCEe6M0MEaxCUWiQ" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_rzZXEWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_rzZ-IGnCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_XExWsHfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_XExWsXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_XExWs3fKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreaming.uml#_X9ay8LqKEemx9sMHf8Tuig"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_rzZXEmnCEe6M0MEaxCUWiQ" x="780" y="-760"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_XExWsnfKEe6iN6ao8wePZw" x="780" y="-760"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_rz67gGnCEe6M0MEaxCUWiQ" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_rz67gWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_rz67g2nCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_XFdTMHfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_XFd6QHfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_XFd6QnfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiOam.uml#_-2fMYF0KEeipas1p-rFJBA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_rz67gmnCEe6M0MEaxCUWiQ" x="1700" y="620"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_XFd6QXfKEe6iN6ao8wePZw" x="1700" y="620"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_r1QYQGnCEe6M0MEaxCUWiQ" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_r1Q_UGnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_r1Q_UmnCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_XG-WIHfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_XG-WIXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_XG-WI3fKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiOam.uml#_RRNb8DU7Eem_pr37XaewKQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_r1Q_UWnCEe6M0MEaxCUWiQ" x="1700" y="760"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_XG-WInfKEe6iN6ao8wePZw" x="1700" y="760"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_r2LlUGnCEe6M0MEaxCUWiQ" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_r2LlUWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_r2LlU2nCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_XICtIHfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_XICtIXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_XICtI3fKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_r2LlUmnCEe6M0MEaxCUWiQ" x="1480" y="640"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_XICtInfKEe6iN6ao8wePZw" x="1480" y="640"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_r2xbMGnCEe6M0MEaxCUWiQ" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_r2xbMWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_r2xbM2nCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_XI2lcHfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_XI2lcXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_XI2lc3fKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiOam.uml#_CE0kkLwmEeSpn78DYJKtkA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_r2xbMmnCEe6M0MEaxCUWiQ" x="1480" y="760"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_XI2lcnfKEe6iN6ao8wePZw" x="1480" y="760"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_r3TmsGnCEe6M0MEaxCUWiQ" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_r3TmsWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_r3Tms2nCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_XJmzYHfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_XJmzYXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_XJnacHfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_r3TmsmnCEe6M0MEaxCUWiQ" x="1480" y="700"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_XJmzYnfKEe6iN6ao8wePZw" x="1480" y="700"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_r32ZQGnCEe6M0MEaxCUWiQ" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_r32ZQWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_r32ZQ2nCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_XKWaQHfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_XKWaQXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_XKWaQ3fKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_UjNPoLzPEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_r32ZQmnCEe6M0MEaxCUWiQ" x="780" y="-640"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_XKWaQnfKEe6iN6ao8wePZw" x="780" y="-640"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_r4QB4GnCEe6M0MEaxCUWiQ" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_r4QB4WnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_r4Qo8GnCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_XK5M0HfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_XK5M0XfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_XK5M03fKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_yH00ALzjEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_r4QB4mnCEe6M0MEaxCUWiQ" x="780" y="-740"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_XK5M0nfKEe6iN6ao8wePZw" x="780" y="-740"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_r4WvkGnCEe6M0MEaxCUWiQ" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_r4WvkWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_r4Wvk2nCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_XLJrgHfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_XLJrgXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_XLKSkHfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_CNum8LzsEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_r4WvkmnCEe6M0MEaxCUWiQ" x="780" y="-740"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_XLJrgnfKEe6iN6ao8wePZw" x="780" y="-740"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_r43s8GnCEe6M0MEaxCUWiQ" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_r43s8WnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_r43s82nCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_XL3dMHfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_XL3dMXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_XL4EQHfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_jAoQkLzREe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_r43s8mnCEe6M0MEaxCUWiQ" x="780" y="-520"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_XL3dMnfKEe6iN6ao8wePZw" x="780" y="-520"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_r5nT0GnCEe6M0MEaxCUWiQ" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_r5nT0WnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_r5nT02nCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_XM3iwHfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_XM3iwXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_XM3iw3fKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_OOMkoLzrEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_r5nT0mnCEe6M0MEaxCUWiQ" x="780" y="-620"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_XM3iwnfKEe6iN6ao8wePZw" x="780" y="-620"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_r519UGnCEe6M0MEaxCUWiQ" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_r519UWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_r519U2nCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_XNNhAHfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_XNNhAXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_XNNhA3fKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_Q6Dt8LzrEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_r519UmnCEe6M0MEaxCUWiQ" x="780" y="-620"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_XNNhAnfKEe6iN6ao8wePZw" x="780" y="-620"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_r6dBUGnCEe6M0MEaxCUWiQ" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_r6dBUWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_r6ePcGnCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_XN42cHfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_XN42cXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_XN5dgHfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_LyQ8cLzlEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_r6dBUmnCEe6M0MEaxCUWiQ" x="780" y="-180"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_XN42cnfKEe6iN6ao8wePZw" x="780" y="-180"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_r600wGnCEe6M0MEaxCUWiQ" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_r600wWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_r600w2nCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_XOWJcHfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_XOWJcXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_XOWJc3fKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_zx-10EOEEe6bIJjw8ZnZGQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_r600wmnCEe6M0MEaxCUWiQ" x="780" y="-280"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_XOWJcnfKEe6iN6ao8wePZw" x="780" y="-280"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_r7aDkGnCEe6M0MEaxCUWiQ" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_r7aDkWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_r7aqoGnCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_XPBe4HfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_XPBe4XfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_XPCtAHfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_Z81vULzmEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_r7aDkmnCEe6M0MEaxCUWiQ" x="720" y="-60"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_XPBe4nfKEe6iN6ao8wePZw" x="720" y="-60"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_r739oGnCEe6M0MEaxCUWiQ" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_r739oWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_r739o2nCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_XPq_IHfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_XPq_IXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_XPq_I3fKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_LqfOkLznEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_r739omnCEe6M0MEaxCUWiQ" x="720" y="-160"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_XPq_InfKEe6iN6ao8wePZw" x="720" y="-160"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_r8clYGnCEe6M0MEaxCUWiQ" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_r8clYWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_r8dMcGnCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_XQVGcHfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_XQVGcXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_XQVtgHfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_PLA5kLzoEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_r8clYmnCEe6M0MEaxCUWiQ" x="780" y="-340"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_XQVGcnfKEe6iN6ao8wePZw" x="780" y="-340"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_r87GgGnCEe6M0MEaxCUWiQ" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_r87GgWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_r87Gg2nCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_XRLbAHfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_XRLbAXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_XRLbA3fKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_aU9CcLzoEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_r87GgmnCEe6M0MEaxCUWiQ" x="780" y="-440"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_XRLbAnfKEe6iN6ao8wePZw" x="780" y="-440"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_r9GFoGnCEe6M0MEaxCUWiQ" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_r9GFoWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_r9GFo2nCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_XRhZQHfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_XRhZQXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_XRiAUHfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_R_-CkLzqEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_r9GFomnCEe6M0MEaxCUWiQ" x="780" y="-440"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_XRhZQnfKEe6iN6ao8wePZw" x="780" y="-440"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_r9oRIGnCEe6M0MEaxCUWiQ" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_r9oRIWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_r9oRI2nCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_XSJrYHfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_XSJrYXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_XSJrY3fKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_jUkBwLzoEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_r9oRImnCEe6M0MEaxCUWiQ" x="220" y="-340"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_XSJrYnfKEe6iN6ao8wePZw" x="220" y="-340"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_r-6qkGnCEe6M0MEaxCUWiQ" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_r-6qkWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_r-6qk2nCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_XTlOwHfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_XTlOwXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_XTlOw3fKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_Gu2rwOi9Ee2WXqIYPh2wfQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_r-6qkmnCEe6M0MEaxCUWiQ" x="720" y="60"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_XTlOwnfKEe6iN6ao8wePZw" x="720" y="60"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_r_WIYGnCEe6M0MEaxCUWiQ" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_r_WIYWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_r_WIY2nCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_XUEW8HfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_XUEW8XfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_XUEW83fKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_eQ-SQOi9Ee2WXqIYPh2wfQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_r_WIYmnCEe6M0MEaxCUWiQ" x="720" y="-40"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_XUEW8nfKEe6iN6ao8wePZw" x="720" y="-40"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_sBcaIGnCEe6M0MEaxCUWiQ" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_sBcaIWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_sBcaI2nCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_XWTLkHfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_XWTLkXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_XWTLk3fKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_KRgyMFIQEe6m_d6KGfEFwg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_sBcaImnCEe6M0MEaxCUWiQ" x="760" y="320"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_XWTLknfKEe6iN6ao8wePZw" x="760" y="320"/>
     </children>
     <styles xsi:type="notation:StringValueStyle" xmi:id="_S30Q4bHDEe2tjo53LmkUFA" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xsi:type="notation:DiagramStyle" xmi:id="_S30Q4rHDEe2tjo53LmkUFA"/>
@@ -4375,325 +4537,325 @@
       <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_WE1kYFISEe6m_d6KGfEFwg" id="(0.0,0.32786885245901637)"/>
       <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_WE1kYVISEe6m_d6KGfEFwg" id="(1.0,0.09950248756218906)"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_ruXtJGnCEe6M0MEaxCUWiQ" type="StereotypeCommentLink" source="_kiIW4bHDEe2tjo53LmkUFA" target="_ruXtIGnCEe6M0MEaxCUWiQ">
-      <styles xsi:type="notation:FontStyle" xmi:id="_ruXtJWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_ruXtKWnCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_W8VMYHfKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_kiIW4bHDEe2tjo53LmkUFA" target="_W8UlUHfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_W8VMYXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_W8VMZXfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_FCwpUKYBEe2n-fmfRwdlPg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_ruXtJmnCEe6M0MEaxCUWiQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_ruXtJ2nCEe6M0MEaxCUWiQ"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_ruXtKGnCEe6M0MEaxCUWiQ"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_W8VMYnfKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_W8VMY3fKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_W8VMZHfKEe6iN6ao8wePZw"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_ruxVwWnCEe6M0MEaxCUWiQ" type="StereotypeCommentLink" source="_Z1cbUEOEEe6bIJjw8ZnZGQ" target="_ruwusGnCEe6M0MEaxCUWiQ">
-      <styles xsi:type="notation:FontStyle" xmi:id="_ruxVwmnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_ruxVxmnCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_W84mAXfKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_Z1cbUEOEEe6bIJjw8ZnZGQ" target="_W83-8HfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_W84mAnfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_W84mBnfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_ZhiA0EOEEe6bIJjw8ZnZGQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_ruxVw2nCEe6M0MEaxCUWiQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_ruxVxGnCEe6M0MEaxCUWiQ"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_ruxVxWnCEe6M0MEaxCUWiQ"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_W84mA3fKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_W84mBHfKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_W84mBXfKEe6iN6ao8wePZw"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_ru3cZGnCEe6M0MEaxCUWiQ" type="StereotypeCommentLink" source="_VYA6oFISEe6m_d6KGfEFwg" target="_ru3cYGnCEe6M0MEaxCUWiQ">
-      <styles xsi:type="notation:FontStyle" xmi:id="_ru3cZWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_ru3caWnCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_W9PLVHfKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_VYA6oFISEe6m_d6KGfEFwg" target="_W9PLUHfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_W9PLVXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_W9PLWXfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_VET7gFISEe6m_d6KGfEFwg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_ru3cZmnCEe6M0MEaxCUWiQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_ru3cZ2nCEe6M0MEaxCUWiQ"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_ru3caGnCEe6M0MEaxCUWiQ"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_W9PLVnfKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_W9PLV3fKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_W9PLWHfKEe6iN6ao8wePZw"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_rvd5VGnCEe6M0MEaxCUWiQ" type="StereotypeCommentLink" source="_kiI9q7HDEe2tjo53LmkUFA" target="_rvd5UGnCEe6M0MEaxCUWiQ">
-      <styles xsi:type="notation:FontStyle" xmi:id="_rvd5VWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_rvd5WWnCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_W-LmgXfKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_kiI9q7HDEe2tjo53LmkUFA" target="_W-K_cHfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_W-LmgnfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_W-LmhnfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiOam.uml#_vnyfgF0IEeipas1p-rFJBA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_rvd5VmnCEe6M0MEaxCUWiQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_rvd5V2nCEe6M0MEaxCUWiQ"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_rvd5WGnCEe6M0MEaxCUWiQ"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_W-Lmg3fKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_W-LmhHfKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_W-LmhXfKEe6iN6ao8wePZw"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_rxOz5GnCEe6M0MEaxCUWiQ" type="StereotypeCommentLink" source="_kiLZ0LHDEe2tjo53LmkUFA" target="_rxOz4GnCEe6M0MEaxCUWiQ">
-      <styles xsi:type="notation:FontStyle" xmi:id="_rxOz5WnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_rxOz6WnCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_XA4VNHfKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_kiLZ0LHDEe2tjo53LmkUFA" target="_XA4VMHfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_XA4VNXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_XA4VOXfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_406Q8KFhEe2n-fmfRwdlPg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_rxOz5mnCEe6M0MEaxCUWiQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_rxOz52nCEe6M0MEaxCUWiQ"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_rxOz6GnCEe6M0MEaxCUWiQ"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_XA4VNnfKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_XA4VN3fKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_XA4VOHfKEe6iN6ao8wePZw"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_ryh0ZGnCEe6M0MEaxCUWiQ" type="StereotypeCommentLink" source="_kiOdILHDEe2tjo53LmkUFA" target="_ryh0YGnCEe6M0MEaxCUWiQ">
-      <styles xsi:type="notation:FontStyle" xmi:id="_ryh0ZWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_ryibcmnCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_XDFUoHfKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_kiOdILHDEe2tjo53LmkUFA" target="_XDEtkHfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_XDFUoXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_XDF7sHfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_Aow5sKFgEe2n-fmfRwdlPg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_ryh0ZmnCEe6M0MEaxCUWiQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_ryibcGnCEe6M0MEaxCUWiQ"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_ryibcWnCEe6M0MEaxCUWiQ"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_XDFUonfKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_XDFUo3fKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_XDFUpHfKEe6iN6ao8wePZw"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_ry5AxGnCEe6M0MEaxCUWiQ" type="StereotypeCommentLink" source="_kiI9kLHDEe2tjo53LmkUFA" target="_ry5AwGnCEe6M0MEaxCUWiQ">
-      <styles xsi:type="notation:FontStyle" xmi:id="_ry5AxWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_ry5AyWnCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_XDrKgXfKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_kiI9kLHDEe2tjo53LmkUFA" target="_XDqjcHfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_XDrKgnfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_XDrKhnfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_SyXM4KYBEe2n-fmfRwdlPg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_ry5AxmnCEe6M0MEaxCUWiQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_ry5Ax2nCEe6M0MEaxCUWiQ"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_ry5AyGnCEe6M0MEaxCUWiQ"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_XDrKg3fKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_XDrKhHfKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_XDrKhXfKEe6iN6ao8wePZw"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_ry_udGnCEe6M0MEaxCUWiQ" type="StereotypeCommentLink" source="__xjboEODEe6bIJjw8ZnZGQ" target="_ry_ucGnCEe6M0MEaxCUWiQ">
-      <styles xsi:type="notation:FontStyle" xmi:id="_ry_udWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_rzAVgGnCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_XD8QRHfKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="__xjboEODEe6bIJjw8ZnZGQ" target="_XD8QQHfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_XD83UHfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_XD83VHfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#__d9xQEODEe6bIJjw8ZnZGQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_ry_udmnCEe6M0MEaxCUWiQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_ry_ud2nCEe6M0MEaxCUWiQ"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_ry_ueGnCEe6M0MEaxCUWiQ"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_XD83UXfKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_XD83UnfKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_XD83U3fKEe6iN6ao8wePZw"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_rzHDMWnCEe6M0MEaxCUWiQ" type="StereotypeCommentLink" source="_TKgMIFIQEe6m_d6KGfEFwg" target="_rzGcIGnCEe6M0MEaxCUWiQ">
-      <styles xsi:type="notation:FontStyle" xmi:id="_rzHDMmnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_rzHDNmnCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_XES1kXfKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_TKgMIFIQEe6m_d6KGfEFwg" target="_XESOgHfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_XES1knfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_XES1lnfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_S1iBsFIQEe6m_d6KGfEFwg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_rzHDM2nCEe6M0MEaxCUWiQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_rzHDNGnCEe6M0MEaxCUWiQ"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_rzHDNWnCEe6M0MEaxCUWiQ"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_XES1k3fKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_XES1lHfKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_XES1lXfKEe6iN6ao8wePZw"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_rzZ-IWnCEe6M0MEaxCUWiQ" type="StereotypeCommentLink" source="_q9G14LHDEe2tjo53LmkUFA" target="_rzZXEGnCEe6M0MEaxCUWiQ">
-      <styles xsi:type="notation:FontStyle" xmi:id="_rzZ-ImnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_rzZ-JmnCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_XEx9wHfKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_q9G14LHDEe2tjo53LmkUFA" target="_XExWsHfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_XEx9wXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_XEx9xXfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiStreaming.uml#_X9ay8LqKEemx9sMHf8Tuig"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_rzZ-I2nCEe6M0MEaxCUWiQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_rzZ-JGnCEe6M0MEaxCUWiQ"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_rzZ-JWnCEe6M0MEaxCUWiQ"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_XEx9wnfKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_XEx9w3fKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_XEx9xHfKEe6iN6ao8wePZw"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_rz67hGnCEe6M0MEaxCUWiQ" type="StereotypeCommentLink" source="_7AfSkLHGEe2tjo53LmkUFA" target="_rz67gGnCEe6M0MEaxCUWiQ">
-      <styles xsi:type="notation:FontStyle" xmi:id="_rz67hWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_rz67iWnCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_XFd6Q3fKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_7AfSkLHGEe2tjo53LmkUFA" target="_XFdTMHfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_XFd6RHfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_XFehUHfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiOam.uml#_-2fMYF0KEeipas1p-rFJBA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_rz67hmnCEe6M0MEaxCUWiQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_rz67h2nCEe6M0MEaxCUWiQ"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_rz67iGnCEe6M0MEaxCUWiQ"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_XFd6RXfKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_XFd6RnfKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_XFd6R3fKEe6iN6ao8wePZw"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_r1Q_U2nCEe6M0MEaxCUWiQ" type="StereotypeCommentLink" source="_Z9c6ALHHEe2tjo53LmkUFA" target="_r1QYQGnCEe6M0MEaxCUWiQ">
-      <styles xsi:type="notation:FontStyle" xmi:id="_r1Q_VGnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_r1Q_WGnCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_XG-9MHfKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_Z9c6ALHHEe2tjo53LmkUFA" target="_XG-WIHfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_XG-9MXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_XG_kQHfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiOam.uml#_RRNb8DU7Eem_pr37XaewKQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_r1Q_VWnCEe6M0MEaxCUWiQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_r1Q_VmnCEe6M0MEaxCUWiQ"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_r1Q_V2nCEe6M0MEaxCUWiQ"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_XG-9MnfKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_XG-9M3fKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_XG-9NHfKEe6iN6ao8wePZw"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_r2LlVGnCEe6M0MEaxCUWiQ" type="StereotypeCommentLink" source="_yn1tgLv2Ee2tPvK7TLwO7Q" target="_r2LlUGnCEe6M0MEaxCUWiQ">
-      <styles xsi:type="notation:FontStyle" xmi:id="_r2LlVWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_r2MMYmnCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_XICtJHfKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_yn1tgLv2Ee2tPvK7TLwO7Q" target="_XICtIHfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_XICtJXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_XIDUMnfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_r2LlVmnCEe6M0MEaxCUWiQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_r2MMYGnCEe6M0MEaxCUWiQ"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_r2MMYWnCEe6M0MEaxCUWiQ"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_XICtJnfKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_XIDUMHfKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_XIDUMXfKEe6iN6ao8wePZw"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_r2xbNGnCEe6M0MEaxCUWiQ" type="StereotypeCommentLink" source="_266sQLv2Ee2tPvK7TLwO7Q" target="_r2xbMGnCEe6M0MEaxCUWiQ">
-      <styles xsi:type="notation:FontStyle" xmi:id="_r2xbNWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_r2xbOWnCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_XI3MgHfKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_266sQLv2Ee2tPvK7TLwO7Q" target="_XI2lcHfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_XI3MgXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_XI3MhXfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiOam.uml#_CE0kkLwmEeSpn78DYJKtkA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_r2xbNmnCEe6M0MEaxCUWiQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_r2xbN2nCEe6M0MEaxCUWiQ"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_r2xbOGnCEe6M0MEaxCUWiQ"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_XI3MgnfKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_XI3Mg3fKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_XI3MhHfKEe6iN6ao8wePZw"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_r3TmtGnCEe6M0MEaxCUWiQ" type="StereotypeCommentLink" source="_5PZ3YLv2Ee2tPvK7TLwO7Q" target="_r3TmsGnCEe6M0MEaxCUWiQ">
-      <styles xsi:type="notation:FontStyle" xmi:id="_r3TmtWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_r3TmuWnCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_XJnacXfKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_5PZ3YLv2Ee2tPvK7TLwO7Q" target="_XJmzYHfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_XJnacnfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_XJoBgXfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_r3TmtmnCEe6M0MEaxCUWiQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_r3Tmt2nCEe6M0MEaxCUWiQ"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_r3TmuGnCEe6M0MEaxCUWiQ"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_XJnac3fKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_XJnadHfKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_XJoBgHfKEe6iN6ao8wePZw"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_r32ZRGnCEe6M0MEaxCUWiQ" type="StereotypeCommentLink" source="_Uje8cLzPEe2tPvK7TLwO7Q" target="_r32ZQGnCEe6M0MEaxCUWiQ">
-      <styles xsi:type="notation:FontStyle" xmi:id="_r32ZRWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_r32ZSWnCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_XKWaRHfKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_Uje8cLzPEe2tPvK7TLwO7Q" target="_XKWaQHfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_XKWaRXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_XKWaSXfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_UjNPoLzPEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_r32ZRmnCEe6M0MEaxCUWiQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_r32ZR2nCEe6M0MEaxCUWiQ"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_r32ZSGnCEe6M0MEaxCUWiQ"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_XKWaRnfKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_XKWaR3fKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_XKWaSHfKEe6iN6ao8wePZw"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_r4Qo8WnCEe6M0MEaxCUWiQ" type="StereotypeCommentLink" source="_yH-lALzjEe2tPvK7TLwO7Q" target="_r4QB4GnCEe6M0MEaxCUWiQ">
-      <styles xsi:type="notation:FontStyle" xmi:id="_r4Qo8mnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_r4Qo9mnCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_XK5M1HfKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_yH-lALzjEe2tPvK7TLwO7Q" target="_XK5M0HfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_XK5M1XfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_XK5M2XfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_yH00ALzjEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_r4Qo82nCEe6M0MEaxCUWiQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_r4Qo9GnCEe6M0MEaxCUWiQ"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_r4Qo9WnCEe6M0MEaxCUWiQ"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_XK5M1nfKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_XK5M13fKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_XK5M2HfKEe6iN6ao8wePZw"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_r4WvlGnCEe6M0MEaxCUWiQ" type="StereotypeCommentLink" source="_C16oULzsEe2tPvK7TLwO7Q" target="_r4WvkGnCEe6M0MEaxCUWiQ">
-      <styles xsi:type="notation:FontStyle" xmi:id="_r4WvlWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_r4WvmWnCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_XLKSkXfKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_C16oULzsEe2tPvK7TLwO7Q" target="_XLJrgHfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_XLKSknfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_XLKSlnfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_CNum8LzsEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_r4WvlmnCEe6M0MEaxCUWiQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_r4Wvl2nCEe6M0MEaxCUWiQ"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_r4WvmGnCEe6M0MEaxCUWiQ"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_XLKSk3fKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_XLKSlHfKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_XLKSlXfKEe6iN6ao8wePZw"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_r43s9GnCEe6M0MEaxCUWiQ" type="StereotypeCommentLink" source="_jAwzcLzREe2tPvK7TLwO7Q" target="_r43s8GnCEe6M0MEaxCUWiQ">
-      <styles xsi:type="notation:FontStyle" xmi:id="_r43s9WnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_r43s-WnCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_XL4EQXfKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_jAwzcLzREe2tPvK7TLwO7Q" target="_XL3dMHfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_XL4EQnfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_XL4rUnfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_jAoQkLzREe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_r43s9mnCEe6M0MEaxCUWiQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_r43s92nCEe6M0MEaxCUWiQ"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_r43s-GnCEe6M0MEaxCUWiQ"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_XL4EQ3fKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_XL4rUHfKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_XL4rUXfKEe6iN6ao8wePZw"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_r5nT1GnCEe6M0MEaxCUWiQ" type="StereotypeCommentLink" source="_Ouue0LzrEe2tPvK7TLwO7Q" target="_r5nT0GnCEe6M0MEaxCUWiQ">
-      <styles xsi:type="notation:FontStyle" xmi:id="_r5nT1WnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_r5nT2WnCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_XM4J0HfKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_Ouue0LzrEe2tPvK7TLwO7Q" target="_XM3iwHfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_XM4J0XfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_XM4J1XfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_OOMkoLzrEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_r5nT1mnCEe6M0MEaxCUWiQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_r5nT12nCEe6M0MEaxCUWiQ"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_r5nT2GnCEe6M0MEaxCUWiQ"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_XM4J0nfKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_XM4J03fKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_XM4J1HfKEe6iN6ao8wePZw"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_r519VGnCEe6M0MEaxCUWiQ" type="StereotypeCommentLink" source="_RaObwLzrEe2tPvK7TLwO7Q" target="_r519UGnCEe6M0MEaxCUWiQ">
-      <styles xsi:type="notation:FontStyle" xmi:id="_r519VWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_r519WWnCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_XNNhBHfKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_RaObwLzrEe2tPvK7TLwO7Q" target="_XNNhAHfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_XNNhBXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_XNNhCXfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_Q6Dt8LzrEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_r519VmnCEe6M0MEaxCUWiQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_r519V2nCEe6M0MEaxCUWiQ"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_r519WGnCEe6M0MEaxCUWiQ"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_XNNhBnfKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_XNNhB3fKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_XNNhCHfKEe6iN6ao8wePZw"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_r6ePcWnCEe6M0MEaxCUWiQ" type="StereotypeCommentLink" source="_LyWcALzlEe2tPvK7TLwO7Q" target="_r6dBUGnCEe6M0MEaxCUWiQ">
-      <styles xsi:type="notation:FontStyle" xmi:id="_r6ePcmnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_r6ePdmnCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_XN5dgXfKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_LyWcALzlEe2tPvK7TLwO7Q" target="_XN42cHfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_XN5dgnfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_XN5dhnfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_LyQ8cLzlEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_r6ePc2nCEe6M0MEaxCUWiQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_r6ePdGnCEe6M0MEaxCUWiQ"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_r6ePdWnCEe6M0MEaxCUWiQ"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_XN5dg3fKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_XN5dhHfKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_XN5dhXfKEe6iN6ao8wePZw"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_r600xGnCEe6M0MEaxCUWiQ" type="StereotypeCommentLink" source="_0FOh8EOEEe6bIJjw8ZnZGQ" target="_r600wGnCEe6M0MEaxCUWiQ">
-      <styles xsi:type="notation:FontStyle" xmi:id="_r600xWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_r600yWnCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_XOWJdHfKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_0FOh8EOEEe6bIJjw8ZnZGQ" target="_XOWJcHfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_XOWJdXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_XOWwgnfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_zx-10EOEEe6bIJjw8ZnZGQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_r600xmnCEe6M0MEaxCUWiQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_r600x2nCEe6M0MEaxCUWiQ"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_r600yGnCEe6M0MEaxCUWiQ"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_XOWJdnfKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_XOWwgHfKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_XOWwgXfKEe6iN6ao8wePZw"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_r7aqoWnCEe6M0MEaxCUWiQ" type="StereotypeCommentLink" source="_Z86n0LzmEe2tPvK7TLwO7Q" target="_r7aDkGnCEe6M0MEaxCUWiQ">
-      <styles xsi:type="notation:FontStyle" xmi:id="_r7aqomnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_r7bRsmnCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_XPCtAXfKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_Z86n0LzmEe2tPvK7TLwO7Q" target="_XPBe4HfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_XPCtAnfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_XPCtBnfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_Z81vULzmEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_r7aqo2nCEe6M0MEaxCUWiQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_r7bRsGnCEe6M0MEaxCUWiQ"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_r7bRsWnCEe6M0MEaxCUWiQ"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_XPCtA3fKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_XPCtBHfKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_XPCtBXfKEe6iN6ao8wePZw"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_r739pGnCEe6M0MEaxCUWiQ" type="StereotypeCommentLink" source="_MKchALznEe2tPvK7TLwO7Q" target="_r739oGnCEe6M0MEaxCUWiQ">
-      <styles xsi:type="notation:FontStyle" xmi:id="_r739pWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_r74ksmnCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_XPq_JHfKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_MKchALznEe2tPvK7TLwO7Q" target="_XPq_IHfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_XPq_JXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_XPq_KXfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_LqfOkLznEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_r739pmnCEe6M0MEaxCUWiQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_r74ksGnCEe6M0MEaxCUWiQ"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_r74ksWnCEe6M0MEaxCUWiQ"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_XPq_JnfKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_XPq_J3fKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_XPq_KHfKEe6iN6ao8wePZw"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_r8dMcWnCEe6M0MEaxCUWiQ" type="StereotypeCommentLink" source="_PLFyELzoEe2tPvK7TLwO7Q" target="_r8clYGnCEe6M0MEaxCUWiQ">
-      <styles xsi:type="notation:FontStyle" xmi:id="_r8dMcmnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_r8dMdmnCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_XQVtgXfKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_PLFyELzoEe2tPvK7TLwO7Q" target="_XQVGcHfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_XQVtgnfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_XQVthnfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_PLA5kLzoEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_r8dMc2nCEe6M0MEaxCUWiQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_r8dMdGnCEe6M0MEaxCUWiQ"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_r8dMdWnCEe6M0MEaxCUWiQ"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_XQVtg3fKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_XQVthHfKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_XQVthXfKEe6iN6ao8wePZw"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_r87GhGnCEe6M0MEaxCUWiQ" type="StereotypeCommentLink" source="_a1ZdELzoEe2tPvK7TLwO7Q" target="_r87GgGnCEe6M0MEaxCUWiQ">
-      <styles xsi:type="notation:FontStyle" xmi:id="_r87GhWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_r87tkGnCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_XRMCEHfKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_a1ZdELzoEe2tPvK7TLwO7Q" target="_XRLbAHfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_XRMCEXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_XRMCFXfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_aU9CcLzoEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_r87GhmnCEe6M0MEaxCUWiQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_r87Gh2nCEe6M0MEaxCUWiQ"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_r87GiGnCEe6M0MEaxCUWiQ"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_XRMCEnfKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_XRMCE3fKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_XRMCFHfKEe6iN6ao8wePZw"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_r9GssGnCEe6M0MEaxCUWiQ" type="StereotypeCommentLink" source="_ShHn0LzqEe2tPvK7TLwO7Q" target="_r9GFoGnCEe6M0MEaxCUWiQ">
-      <styles xsi:type="notation:FontStyle" xmi:id="_r9GssWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_r9GstWnCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_XRiAUXfKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_ShHn0LzqEe2tPvK7TLwO7Q" target="_XRhZQHfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_XRiAUnfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_XRiAVnfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_R_-CkLzqEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_r9GssmnCEe6M0MEaxCUWiQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_r9Gss2nCEe6M0MEaxCUWiQ"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_r9GstGnCEe6M0MEaxCUWiQ"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_XRiAU3fKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_XRiAVHfKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_XRiAVXfKEe6iN6ao8wePZw"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_r9oRJGnCEe6M0MEaxCUWiQ" type="StereotypeCommentLink" source="_jUyEMLzoEe2tPvK7TLwO7Q" target="_r9oRIGnCEe6M0MEaxCUWiQ">
-      <styles xsi:type="notation:FontStyle" xmi:id="_r9oRJWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_r9o4MmnCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_XSJrZHfKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_jUyEMLzoEe2tPvK7TLwO7Q" target="_XSJrYHfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_XSJrZXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_XSKScnfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_jUkBwLzoEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_r9oRJmnCEe6M0MEaxCUWiQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_r9o4MGnCEe6M0MEaxCUWiQ"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_r9o4MWnCEe6M0MEaxCUWiQ"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_XSJrZnfKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_XSKScHfKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_XSKScXfKEe6iN6ao8wePZw"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_r-6qlGnCEe6M0MEaxCUWiQ" type="StereotypeCommentLink" source="_GvHxgOi9Ee2WXqIYPh2wfQ" target="_r-6qkGnCEe6M0MEaxCUWiQ">
-      <styles xsi:type="notation:FontStyle" xmi:id="_r-6qlWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_r-6qmWnCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_XTlOxHfKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_GvHxgOi9Ee2WXqIYPh2wfQ" target="_XTlOwHfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_XTlOxXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_XTl10nfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_Gu2rwOi9Ee2WXqIYPh2wfQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_r-6qlmnCEe6M0MEaxCUWiQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_r-6ql2nCEe6M0MEaxCUWiQ"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_r-6qmGnCEe6M0MEaxCUWiQ"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_XTlOxnfKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_XTl10HfKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_XTl10XfKEe6iN6ao8wePZw"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_r_WIZGnCEe6M0MEaxCUWiQ" type="StereotypeCommentLink" source="_e010UOi9Ee2WXqIYPh2wfQ" target="_r_WIYGnCEe6M0MEaxCUWiQ">
-      <styles xsi:type="notation:FontStyle" xmi:id="_r_WIZWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_r_WIaWnCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_XUEW9HfKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_e010UOi9Ee2WXqIYPh2wfQ" target="_XUEW8HfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_XUEW9XfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_XUE-AnfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_eQ-SQOi9Ee2WXqIYPh2wfQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_r_WIZmnCEe6M0MEaxCUWiQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_r_WIZ2nCEe6M0MEaxCUWiQ"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_r_WIaGnCEe6M0MEaxCUWiQ"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_XUEW9nfKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_XUE-AHfKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_XUE-AXfKEe6iN6ao8wePZw"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_sBcaJGnCEe6M0MEaxCUWiQ" type="StereotypeCommentLink" source="_KSJrYFIQEe6m_d6KGfEFwg" target="_sBcaIGnCEe6M0MEaxCUWiQ">
-      <styles xsi:type="notation:FontStyle" xmi:id="_sBcaJWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_sBcaKWnCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_XWTLlHfKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_KSJrYFIQEe6m_d6KGfEFwg" target="_XWTLkHfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_XWTLlXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_XWTyonfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_KRgyMFIQEe6m_d6KGfEFwg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_sBcaJmnCEe6M0MEaxCUWiQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_sBcaJ2nCEe6M0MEaxCUWiQ"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_sBcaKGnCEe6M0MEaxCUWiQ"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_XWTLlnfKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_XWTyoHfKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_XWTyoXfKEe6iN6ao8wePZw"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_B8tVAEJaEe6tO8bOoJ4-CQ" type="PapyrusUMLClassDiagram" name="GnmiStreamStructure" measurementUnit="Pixel">
@@ -6795,93 +6957,93 @@
       <element href="TapiGnmiStreaming.uml#_406Q8KFhEe2n-fmfRwdlPg"/>
       <layoutConstraint xsi:type="notation:Bounds" xmi:id="_YTVPTVIUEe6m_d6KGfEFwg" x="200" y="780" width="541" height="221"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_nEkF4GnBEe6M0MEaxCUWiQ" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_nEkF4WnBEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_nEkF42nBEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_qyA9YHfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_qyA9YXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_qyA9Y3fKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_Z81vULzmEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_nEkF4mnBEe6M0MEaxCUWiQ" x="420" y="140"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_qyA9YnfKEe6iN6ao8wePZw" x="420" y="140"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_nGIMIGnBEe6M0MEaxCUWiQ" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_nGIMIWnBEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_nGIzMGnBEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_qyXisHfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_qyXisXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_qyYJwHfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_LqfOkLznEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_nGIMImnBEe6M0MEaxCUWiQ" x="420" y="40"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_qyXisnfKEe6iN6ao8wePZw" x="420" y="40"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_nGweQGnBEe6M0MEaxCUWiQ" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_nGxFUGnBEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_nGxFUmnBEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_qyuvEHfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_qyuvEXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_qyv9MHfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_Gu2rwOi9Ee2WXqIYPh2wfQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_nGxFUWnBEe6M0MEaxCUWiQ" x="420" y="260"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_qyuvEnfKEe6iN6ao8wePZw" x="420" y="260"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_nHNKMGnBEe6M0MEaxCUWiQ" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_nHNKMWnBEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_nHNKM2nBEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_qzEtUHfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_qzEtUXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_qzEtU3fKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_eQ-SQOi9Ee2WXqIYPh2wfQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_nHNKMmnBEe6M0MEaxCUWiQ" x="420" y="160"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_qzEtUnfKEe6iN6ao8wePZw" x="420" y="160"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_nHpPEGnBEe6M0MEaxCUWiQ" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_nHpPEWnBEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_nHpPE2nBEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_qze9AHfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_qze9AXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_qzfkEHfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_KRgyMFIQEe6m_d6KGfEFwg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_nHpPEmnBEe6M0MEaxCUWiQ" x="460" y="520"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_qze9AnfKEe6iN6ao8wePZw" x="460" y="520"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_nJfCIGnBEe6M0MEaxCUWiQ" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_nJfCIWnBEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_nJfCI2nBEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_q07HcHfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_q07HcXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_q07Hc3fKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_Aow5sKFgEe2n-fmfRwdlPg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_nJfCImnBEe6M0MEaxCUWiQ" x="420" y="380"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_q07HcnfKEe6iN6ao8wePZw" x="420" y="380"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_nJ-KUGnBEe6M0MEaxCUWiQ" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_nJ-KUWnBEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_nJ-KU2nBEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_q1ST0HfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_q1ST0XfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_q1ST03fKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#__d9xQEODEe6bIJjw8ZnZGQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_nJ-KUmnBEe6M0MEaxCUWiQ" x="420" y="280"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_q1ST0nfKEe6iN6ao8wePZw" x="420" y="280"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_nKHUQGnBEe6M0MEaxCUWiQ" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_nKHUQWnBEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_nKHUQ2nBEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_q1ehEHfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_q1ehEXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_q1ehE3fKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_S1iBsFIQEe6m_d6KGfEFwg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_nKHUQmnBEe6M0MEaxCUWiQ" x="420" y="280"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_q1ehEnfKEe6iN6ao8wePZw" x="420" y="280"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_nKnqkGnBEe6M0MEaxCUWiQ" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_nKnqkWnBEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_nKoRoGnBEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_q1z4QHfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_q1z4QXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_q1z4Q3fKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_LyQ8cLzlEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_nKnqkmnBEe6M0MEaxCUWiQ" x="420" y="20"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_q1z4QnfKEe6iN6ao8wePZw" x="420" y="20"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_nK7MkGnBEe6M0MEaxCUWiQ" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_nK7MkWnBEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_nK7Mk2nBEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_q2DI0HfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_q2DI0XfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_q2DI03fKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_zx-10EOEEe6bIJjw8ZnZGQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_nK7MkmnBEe6M0MEaxCUWiQ" x="420" y="-80"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_q2DI0nfKEe6iN6ao8wePZw" x="420" y="-80"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_nLTnEGnBEe6M0MEaxCUWiQ" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_nLTnEWnBEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_nLTnE2nBEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_q2fNsHfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_q2fNsXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_q2fNs3fKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_406Q8KFhEe2n-fmfRwdlPg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_nLTnEmnBEe6M0MEaxCUWiQ" x="400" y="780"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_q2fNsnfKEe6iN6ao8wePZw" x="400" y="780"/>
     </children>
     <styles xsi:type="notation:StringValueStyle" xmi:id="_jtP3UUJaEe6tO8bOoJ4-CQ" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xsi:type="notation:DiagramStyle" xmi:id="_jtP3UkJaEe6tO8bOoJ4-CQ"/>
@@ -7069,115 +7231,115 @@
       <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_YTVPplIUEe6m_d6KGfEFwg" id="(0.4979253112033195,1.0)"/>
       <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_YTVPp1IUEe6m_d6KGfEFwg" id="(0.4984423676012461,0.0)"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_nEkF5GnBEe6M0MEaxCUWiQ" type="StereotypeCommentLink" source="_YTTVIFIUEe6m_d6KGfEFwg" target="_nEkF4GnBEe6M0MEaxCUWiQ">
-      <styles xsi:type="notation:FontStyle" xmi:id="_nEkF5WnBEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_nEks8GnBEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_qyA9ZHfKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_YTTVIFIUEe6m_d6KGfEFwg" target="_qyA9YHfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_qyA9ZXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_qyBkcHfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_Z81vULzmEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_nEkF5mnBEe6M0MEaxCUWiQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_nEkF52nBEe6M0MEaxCUWiQ"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_nEkF6GnBEe6M0MEaxCUWiQ"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_qyA9ZnfKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_qyA9Z3fKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_qyA9aHfKEe6iN6ao8wePZw"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_nGIzMWnBEe6M0MEaxCUWiQ" type="StereotypeCommentLink" source="_YTVKUFIUEe6m_d6KGfEFwg" target="_nGIMIGnBEe6M0MEaxCUWiQ">
-      <styles xsi:type="notation:FontStyle" xmi:id="_nGIzMmnBEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_nGJaQmnBEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_qyYJwXfKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_YTVKUFIUEe6m_d6KGfEFwg" target="_qyXisHfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_qyYJwnfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_qyYJxnfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_LqfOkLznEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_nGIzM2nBEe6M0MEaxCUWiQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_nGJaQGnBEe6M0MEaxCUWiQ"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_nGJaQWnBEe6M0MEaxCUWiQ"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_qyYJw3fKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_qyYJxHfKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_qyYJxXfKEe6iN6ao8wePZw"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_nGxFU2nBEe6M0MEaxCUWiQ" type="StereotypeCommentLink" source="_YTVKblIUEe6m_d6KGfEFwg" target="_nGweQGnBEe6M0MEaxCUWiQ">
-      <styles xsi:type="notation:FontStyle" xmi:id="_nGxFVGnBEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_nGxFWGnBEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_qyv9MXfKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_YTVKblIUEe6m_d6KGfEFwg" target="_qyuvEHfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_qyv9MnfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_qyv9NnfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_Gu2rwOi9Ee2WXqIYPh2wfQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_nGxFVWnBEe6M0MEaxCUWiQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_nGxFVmnBEe6M0MEaxCUWiQ"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_nGxFV2nBEe6M0MEaxCUWiQ"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_qyv9M3fKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_qyv9NHfKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_qyv9NXfKEe6iN6ao8wePZw"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_nHNKNGnBEe6M0MEaxCUWiQ" type="StereotypeCommentLink" source="_YTVPTlIUEe6m_d6KGfEFwg" target="_nHNKMGnBEe6M0MEaxCUWiQ">
-      <styles xsi:type="notation:FontStyle" xmi:id="_nHNKNWnBEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_nHNKOWnBEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_qzEtVHfKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_YTVPTlIUEe6m_d6KGfEFwg" target="_qzEtUHfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_qzEtVXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_qzEtWXfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_eQ-SQOi9Ee2WXqIYPh2wfQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_nHNKNmnBEe6M0MEaxCUWiQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_nHNKN2nBEe6M0MEaxCUWiQ"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_nHNKOGnBEe6M0MEaxCUWiQ"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_qzEtVnfKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_qzEtV3fKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_qzEtWHfKEe6iN6ao8wePZw"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_nHpPFGnBEe6M0MEaxCUWiQ" type="StereotypeCommentLink" source="_YTVK41IUEe6m_d6KGfEFwg" target="_nHpPEGnBEe6M0MEaxCUWiQ">
-      <styles xsi:type="notation:FontStyle" xmi:id="_nHpPFWnBEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_nHpPGWnBEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_qzfkEXfKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_YTVK41IUEe6m_d6KGfEFwg" target="_qze9AHfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_qzfkEnfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_qzfkFnfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_KRgyMFIQEe6m_d6KGfEFwg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_nHpPFmnBEe6M0MEaxCUWiQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_nHpPF2nBEe6M0MEaxCUWiQ"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_nHpPGGnBEe6M0MEaxCUWiQ"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_qzfkE3fKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_qzfkFHfKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_qzfkFXfKEe6iN6ao8wePZw"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_nJfCJGnBEe6M0MEaxCUWiQ" type="StereotypeCommentLink" source="_YTVNNlIUEe6m_d6KGfEFwg" target="_nJfCIGnBEe6M0MEaxCUWiQ">
-      <styles xsi:type="notation:FontStyle" xmi:id="_nJfCJWnBEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_nJfpMmnBEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_q07HdHfKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_YTVNNlIUEe6m_d6KGfEFwg" target="_q07HcHfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_q07HdXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_q07ugHfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_Aow5sKFgEe2n-fmfRwdlPg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_nJfCJmnBEe6M0MEaxCUWiQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_nJfpMGnBEe6M0MEaxCUWiQ"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_nJfpMWnBEe6M0MEaxCUWiQ"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_q07HdnfKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_q07Hd3fKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_q07HeHfKEe6iN6ao8wePZw"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_nJ-KVGnBEe6M0MEaxCUWiQ" type="StereotypeCommentLink" source="_YTVNq1IUEe6m_d6KGfEFwg" target="_nJ-KUGnBEe6M0MEaxCUWiQ">
-      <styles xsi:type="notation:FontStyle" xmi:id="_nJ-KVWnBEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_nJ-KWWnBEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_q1ST1HfKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_YTVNq1IUEe6m_d6KGfEFwg" target="_q1ST0HfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_q1ST1XfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_q1S64HfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#__d9xQEODEe6bIJjw8ZnZGQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_nJ-KVmnBEe6M0MEaxCUWiQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_nJ-KV2nBEe6M0MEaxCUWiQ"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_nJ-KWGnBEe6M0MEaxCUWiQ"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_q1ST1nfKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_q1ST13fKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_q1ST2HfKEe6iN6ao8wePZw"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_nKHURGnBEe6M0MEaxCUWiQ" type="StereotypeCommentLink" source="_YTVPbFIUEe6m_d6KGfEFwg" target="_nKHUQGnBEe6M0MEaxCUWiQ">
-      <styles xsi:type="notation:FontStyle" xmi:id="_nKHURWnBEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_nKHUSWnBEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_q1ehFHfKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_YTVPbFIUEe6m_d6KGfEFwg" target="_q1ehEHfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_q1ehFXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_q1ehGXfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_S1iBsFIQEe6m_d6KGfEFwg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_nKHURmnBEe6M0MEaxCUWiQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_nKHUR2nBEe6M0MEaxCUWiQ"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_nKHUSGnBEe6M0MEaxCUWiQ"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_q1ehFnfKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_q1ehF3fKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_q1ehGHfKEe6iN6ao8wePZw"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_nKoRoWnBEe6M0MEaxCUWiQ" type="StereotypeCommentLink" source="_YTVNyVIUEe6m_d6KGfEFwg" target="_nKnqkGnBEe6M0MEaxCUWiQ">
-      <styles xsi:type="notation:FontStyle" xmi:id="_nKoRomnBEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_nKoRpmnBEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_q1z4RHfKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_YTVNyVIUEe6m_d6KGfEFwg" target="_q1z4QHfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_q1z4RXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_q1z4SXfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_LyQ8cLzlEe2tPvK7TLwO7Q"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_nKoRo2nBEe6M0MEaxCUWiQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_nKoRpGnBEe6M0MEaxCUWiQ"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_nKoRpWnBEe6M0MEaxCUWiQ"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_q1z4RnfKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_q1z4R3fKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_q1z4SHfKEe6iN6ao8wePZw"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_nK7MlGnBEe6M0MEaxCUWiQ" type="StereotypeCommentLink" source="_YTVPilIUEe6m_d6KGfEFwg" target="_nK7MkGnBEe6M0MEaxCUWiQ">
-      <styles xsi:type="notation:FontStyle" xmi:id="_nK7MlWnBEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_nK7MmWnBEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_q2DI1HfKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_YTVPilIUEe6m_d6KGfEFwg" target="_q2DI0HfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_q2DI1XfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_q2DI2XfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_zx-10EOEEe6bIJjw8ZnZGQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_nK7MlmnBEe6M0MEaxCUWiQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_nK7Ml2nBEe6M0MEaxCUWiQ"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_nK7MmGnBEe6M0MEaxCUWiQ"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_q2DI1nfKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_q2DI13fKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_q2DI2HfKEe6iN6ao8wePZw"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_nLTnFGnBEe6M0MEaxCUWiQ" type="StereotypeCommentLink" source="_YTVOClIUEe6m_d6KGfEFwg" target="_nLTnEGnBEe6M0MEaxCUWiQ">
-      <styles xsi:type="notation:FontStyle" xmi:id="_nLTnFWnBEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_nLTnGWnBEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_q2f0wHfKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_YTVOClIUEe6m_d6KGfEFwg" target="_q2fNsHfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_q2f0wXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_q2f0xXfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_406Q8KFhEe2n-fmfRwdlPg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_nLTnFmnBEe6M0MEaxCUWiQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_nLTnF2nBEe6M0MEaxCUWiQ"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_nLTnGGnBEe6M0MEaxCUWiQ"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_q2f0wnfKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_q2f0w3fKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_q2f0xHfKEe6iN6ao8wePZw"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_DJT1kEJbEe6tO8bOoJ4-CQ" type="PapyrusUMLClassDiagram" name="MultipleMeasurementReportingStructure" measurementUnit="Pixel">
@@ -8156,77 +8318,77 @@
       <element href="TapiGnmiStreaming.uml#_e1WCUEJcEe6tO8bOoJ4-CQ"/>
       <layoutConstraint xsi:type="notation:Bounds" xmi:id="_cHEetWaBEe6bwd8NmC1HOg" x="34" y="302" width="161" height="21"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_lHNYsGadEe6yfMZde7QaEA" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_lHNYsWadEe6yfMZde7QaEA"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_lHN_wGadEe6yfMZde7QaEA" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_vMRiMHfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_vMRiMXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_vMRiM3fKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_KRgyMFIQEe6m_d6KGfEFwg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_lHNYsmadEe6yfMZde7QaEA" x="100" y="100"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_vMRiMnfKEe6iN6ao8wePZw" x="494" y="102"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_lI7P8GadEe6yfMZde7QaEA" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_lI7P8WadEe6yfMZde7QaEA"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_lI7P82adEe6yfMZde7QaEA" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_vOgW0HfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_vOgW0XfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_vOgW03fKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_FCwpUKYBEe2n-fmfRwdlPg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_lI7P8madEe6yfMZde7QaEA" x="920" y="100"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_vOgW0nfKEe6iN6ao8wePZw" x="1314" y="102"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_lJgewGadEe6yfMZde7QaEA" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_lJgewWadEe6yfMZde7QaEA"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_lJhF0GadEe6yfMZde7QaEA" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_vPIo8HfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_vPIo8XfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_vPJQAHfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_ZhiA0EOEEe6bIJjw8ZnZGQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_lJgewmadEe6yfMZde7QaEA" x="920"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_vPIo8nfKEe6iN6ao8wePZw" x="1314" y="2"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_lJzZsGadEe6yfMZde7QaEA" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_lJzZsWadEe6yfMZde7QaEA"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_lJ0AwGadEe6yfMZde7QaEA" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_vPcK8HfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_vPcK8XfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_vPcyAHfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_VET7gFISEe6m_d6KGfEFwg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_lJzZsmadEe6yfMZde7QaEA" x="920"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_vPcK8nfKEe6iN6ao8wePZw" x="1314" y="2"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_lKf9QGadEe6yfMZde7QaEA" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_lKf9QWadEe6yfMZde7QaEA"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_lKgkUGadEe6yfMZde7QaEA" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_vQGSQHfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_vQGSQXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_vQG5UHfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_Aow5sKFgEe2n-fmfRwdlPg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_lKf9QmadEe6yfMZde7QaEA" x="60" y="-40"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_vQGSQnfKEe6iN6ao8wePZw" x="454" y="-38"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_lK_sgGadEe6yfMZde7QaEA" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_lK_sgWadEe6yfMZde7QaEA"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_lK_sg2adEe6yfMZde7QaEA" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_vQy10HfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_vQy10XfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_vQy103fKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_S1iBsFIQEe6m_d6KGfEFwg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_lK_sgmadEe6yfMZde7QaEA" x="60" y="-140"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_vQy10nfKEe6iN6ao8wePZw" x="454" y="-138"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_lLMg0GadEe6yfMZde7QaEA" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_lLMg0WadEe6yfMZde7QaEA"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_lLMg02adEe6yfMZde7QaEA" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_vRFwwHfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_vRGX0HfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_vRGX0nfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_SyXM4KYBEe2n-fmfRwdlPg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_lLMg0madEe6yfMZde7QaEA" x="60" y="-140"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_vRGX0XfKEe6iN6ao8wePZw" x="454" y="-138"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_lLYHAGadEe6yfMZde7QaEA" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_lLYHAWadEe6yfMZde7QaEA"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_lLYuEGadEe6yfMZde7QaEA" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_vRbH8HfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_vRbH8XfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_vRbH83fKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#__d9xQEODEe6bIJjw8ZnZGQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_lLYHAmadEe6yfMZde7QaEA" x="60" y="-140"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_vRbH8nfKEe6iN6ao8wePZw" x="454" y="-138"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_lL_LAGadEe6yfMZde7QaEA" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_lL_LAWadEe6yfMZde7QaEA"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_lL_LA2adEe6yfMZde7QaEA" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_vSAWwHfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_vSAWwXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_vSAWw3fKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_406Q8KFhEe2n-fmfRwdlPg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_lL_LAmadEe6yfMZde7QaEA" x="40" y="360"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_vSAWwnfKEe6iN6ao8wePZw" x="434" y="362"/>
     </children>
     <styles xsi:type="notation:StringValueStyle" xmi:id="_DJT1kUJbEe6tO8bOoJ4-CQ" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xsi:type="notation:DiagramStyle" xmi:id="_DJT1kkJbEe6tO8bOoJ4-CQ"/>
@@ -8420,95 +8582,95 @@
       <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_D2VwFVIVEe6m_d6KGfEFwg" id="(0.06230529595015576,1.0)"/>
       <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_D2VwFlIVEe6m_d6KGfEFwg" id="(0.07393715341959335,0.0)"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_lHN_wWadEe6yfMZde7QaEA" type="StereotypeCommentLink" source="_D2VsQFIVEe6m_d6KGfEFwg" target="_lHNYsGadEe6yfMZde7QaEA">
-      <styles xsi:type="notation:FontStyle" xmi:id="_lHN_wmadEe6yfMZde7QaEA"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_lHN_xmadEe6yfMZde7QaEA" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_vMRiNHfKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_D2VsQFIVEe6m_d6KGfEFwg" target="_vMRiMHfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_vMRiNXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_vMSJQnfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_KRgyMFIQEe6m_d6KGfEFwg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_lHN_w2adEe6yfMZde7QaEA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_lHN_xGadEe6yfMZde7QaEA"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_lHN_xWadEe6yfMZde7QaEA"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_vMRiNnfKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_vMSJQHfKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_vMSJQXfKEe6iN6ao8wePZw"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_lI7P9GadEe6yfMZde7QaEA" type="StereotypeCommentLink" source="_D2Vuk1IVEe6m_d6KGfEFwg" target="_lI7P8GadEe6yfMZde7QaEA">
-      <styles xsi:type="notation:FontStyle" xmi:id="_lI7P9WadEe6yfMZde7QaEA"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_lI7P-WadEe6yfMZde7QaEA" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_vOgW1HfKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_D2Vuk1IVEe6m_d6KGfEFwg" target="_vOgW0HfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_vOgW1XfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_vOg94nfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_FCwpUKYBEe2n-fmfRwdlPg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_lI7P9madEe6yfMZde7QaEA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_lI7P92adEe6yfMZde7QaEA"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_lI7P-GadEe6yfMZde7QaEA"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_vOgW1nfKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_vOg94HfKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_vOg94XfKEe6iN6ao8wePZw"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_lJhs4GadEe6yfMZde7QaEA" type="StereotypeCommentLink" source="_D2VvKlIVEe6m_d6KGfEFwg" target="_lJgewGadEe6yfMZde7QaEA">
-      <styles xsi:type="notation:FontStyle" xmi:id="_lJhs4WadEe6yfMZde7QaEA"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_lJhs5WadEe6yfMZde7QaEA" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_vPJQAXfKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_D2VvKlIVEe6m_d6KGfEFwg" target="_vPIo8HfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_vPJQAnfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_vPJQBnfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_ZhiA0EOEEe6bIJjw8ZnZGQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_lJhs4madEe6yfMZde7QaEA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_lJhs42adEe6yfMZde7QaEA"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_lJhs5GadEe6yfMZde7QaEA"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_vPJQA3fKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_vPJQBHfKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_vPJQBXfKEe6iN6ao8wePZw"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_lJ0AwWadEe6yfMZde7QaEA" type="StereotypeCommentLink" source="_D2Vv21IVEe6m_d6KGfEFwg" target="_lJzZsGadEe6yfMZde7QaEA">
-      <styles xsi:type="notation:FontStyle" xmi:id="_lJ0AwmadEe6yfMZde7QaEA"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_lJ0AxmadEe6yfMZde7QaEA" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_vPcyAXfKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_D2Vv21IVEe6m_d6KGfEFwg" target="_vPcK8HfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_vPcyAnfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_vPcyBnfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_VET7gFISEe6m_d6KGfEFwg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_lJ0Aw2adEe6yfMZde7QaEA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_lJ0AxGadEe6yfMZde7QaEA"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_lJ0AxWadEe6yfMZde7QaEA"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_vPcyA3fKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_vPcyBHfKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_vPcyBXfKEe6iN6ao8wePZw"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_lKgkUWadEe6yfMZde7QaEA" type="StereotypeCommentLink" source="_D2VvZlIVEe6m_d6KGfEFwg" target="_lKf9QGadEe6yfMZde7QaEA">
-      <styles xsi:type="notation:FontStyle" xmi:id="_lKgkUmadEe6yfMZde7QaEA"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_lKgkVmadEe6yfMZde7QaEA" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_vQG5UXfKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_D2VvZlIVEe6m_d6KGfEFwg" target="_vQGSQHfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_vQG5UnfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_vQG5VnfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_Aow5sKFgEe2n-fmfRwdlPg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_lKgkU2adEe6yfMZde7QaEA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_lKgkVGadEe6yfMZde7QaEA"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_lKgkVWadEe6yfMZde7QaEA"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_vQG5U3fKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_vQG5VHfKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_vQG5VXfKEe6iN6ao8wePZw"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_lK_shGadEe6yfMZde7QaEA" type="StereotypeCommentLink" source="_D2VvDFIVEe6m_d6KGfEFwg" target="_lK_sgGadEe6yfMZde7QaEA">
-      <styles xsi:type="notation:FontStyle" xmi:id="_lLATkGadEe6yfMZde7QaEA"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_lLATlGadEe6yfMZde7QaEA" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_vQy11HfKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_D2VvDFIVEe6m_d6KGfEFwg" target="_vQy10HfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_vQy11XfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_vQy12XfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_S1iBsFIQEe6m_d6KGfEFwg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_lLATkWadEe6yfMZde7QaEA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_lLATkmadEe6yfMZde7QaEA"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_lLATk2adEe6yfMZde7QaEA"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_vQy11nfKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_vQy113fKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_vQy12HfKEe6iN6ao8wePZw"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_lLMg1GadEe6yfMZde7QaEA" type="StereotypeCommentLink" source="_D2VvSFIVEe6m_d6KGfEFwg" target="_lLMg0GadEe6yfMZde7QaEA">
-      <styles xsi:type="notation:FontStyle" xmi:id="_lLMg1WadEe6yfMZde7QaEA"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_lLMg2WadEe6yfMZde7QaEA" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_vRGX03fKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_D2VvSFIVEe6m_d6KGfEFwg" target="_vRFwwHfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_vRGX1HfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_vRGX2HfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_SyXM4KYBEe2n-fmfRwdlPg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_lLMg1madEe6yfMZde7QaEA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_lLMg12adEe6yfMZde7QaEA"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_lLMg2GadEe6yfMZde7QaEA"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_vRGX1XfKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_vRGX1nfKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_vRGX13fKEe6iN6ao8wePZw"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_lLYuEWadEe6yfMZde7QaEA" type="StereotypeCommentLink" source="_D2Vv-VIVEe6m_d6KGfEFwg" target="_lLYHAGadEe6yfMZde7QaEA">
-      <styles xsi:type="notation:FontStyle" xmi:id="_lLYuEmadEe6yfMZde7QaEA"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_lLYuFmadEe6yfMZde7QaEA" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_vRbH9HfKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_D2Vv-VIVEe6m_d6KGfEFwg" target="_vRbH8HfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_vRbH9XfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_vRbvAHfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#__d9xQEODEe6bIJjw8ZnZGQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_lLYuE2adEe6yfMZde7QaEA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_lLYuFGadEe6yfMZde7QaEA"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_lLYuFWadEe6yfMZde7QaEA"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_vRbH9nfKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_vRbH93fKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_vRbH-HfKEe6iN6ao8wePZw"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_lL_LBGadEe6yfMZde7QaEA" type="StereotypeCommentLink" source="_D2VwF1IVEe6m_d6KGfEFwg" target="_lL_LAGadEe6yfMZde7QaEA">
-      <styles xsi:type="notation:FontStyle" xmi:id="_lL_LBWadEe6yfMZde7QaEA"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_lL_LCWadEe6yfMZde7QaEA" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_vSAWxHfKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_D2VwF1IVEe6m_d6KGfEFwg" target="_vSAWwHfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_vSAWxXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_vSAWyXfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_406Q8KFhEe2n-fmfRwdlPg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_lL_LBmadEe6yfMZde7QaEA" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_lL_LB2adEe6yfMZde7QaEA"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_lL_LCGadEe6yfMZde7QaEA"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_vSAWxnfKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_vSAWx3fKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_vSAWyHfKEe6iN6ao8wePZw"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_TSlUUEJdEe6tO8bOoJ4-CQ" type="PapyrusUMLClassDiagram" name="RelatedClasses" measurementUnit="Pixel">
@@ -9032,61 +9194,61 @@
       <element href="TapiGnmiStreaming.uml#_QnzlkEJcEe6tO8bOoJ4-CQ"/>
       <layoutConstraint xsi:type="notation:Bounds" xmi:id="_R_e4S0JeEe6tO8bOoJ4-CQ" x="120" y="300" width="121" height="21"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_0tUlIGnCEe6M0MEaxCUWiQ" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_0tUlIWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_0tUlI2nCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_yD7r0HfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_yD7r0XfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_yD8S4HfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_406Q8KFhEe2n-fmfRwdlPg"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_0tUlImnCEe6M0MEaxCUWiQ" x="240"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_yD7r0nfKEe6iN6ao8wePZw" x="240"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_0uQZQGnCEe6M0MEaxCUWiQ" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_0uQZQWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_0uQZQ2nCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_yEwyQHfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_yEwyQXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_yEwyQ3fKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiOam.uml#_-2fMYF0KEeipas1p-rFJBA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_0uQZQmnCEe6M0MEaxCUWiQ" x="1120" y="220"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_yEwyQnfKEe6iN6ao8wePZw" x="1120" y="220"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_0vcFAGnCEe6M0MEaxCUWiQ" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_0vcFAWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_0vcsEGnCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_yFt0gHfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_yFt0gXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_yFubkHfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_0vcFAmnCEe6M0MEaxCUWiQ" x="840" y="180"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_yFt0gnfKEe6iN6ao8wePZw" x="840" y="180"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_0wDJAGnCEe6M0MEaxCUWiQ" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_0wDJAWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_0wDwEGnCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_yGLHgHfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_yGLHgXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_yGLHg3fKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_0wDJAmnCEe6M0MEaxCUWiQ" x="840" y="120"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_yGLHgnfKEe6iN6ao8wePZw" x="840" y="120"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_0wrbIGnCEe6M0MEaxCUWiQ" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_0wrbIWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_0wrbI2nCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_yGi68HfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_yGi68XfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_yGi683fKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiOam.uml#_RRNb8DU7Eem_pr37XaewKQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_0wrbImnCEe6M0MEaxCUWiQ" x="840" y="300"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_yGi68nfKEe6iN6ao8wePZw" x="840" y="300"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_0xy1cGnCEe6M0MEaxCUWiQ" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_0xy1cWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_0xy1c2nCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_yHPegHfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_yHPegXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_yHPeg3fKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiOam.uml#_vnyfgF0IEeipas1p-rFJBA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_0xy1cmnCEe6M0MEaxCUWiQ" x="1120"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_yHPegnfKEe6iN6ao8wePZw" x="1120"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_0zmMQGnCEe6M0MEaxCUWiQ" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_0zmMQWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_0zmMQ2nCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <children xsi:type="notation:Shape" xmi:id="_yIjGEHfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_yIjGEXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_yIjtIHfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiOam.uml#_CE0kkLwmEeSpn78DYJKtkA"/>
       </styles>
       <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_0zmMQmnCEe6M0MEaxCUWiQ" x="840" y="240"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_yIjGEnfKEe6iN6ao8wePZw" x="840" y="240"/>
     </children>
     <styles xsi:type="notation:StringValueStyle" xmi:id="_TSlUUUJdEe6tO8bOoJ4-CQ" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xsi:type="notation:DiagramStyle" xmi:id="_TSlUUkJdEe6tO8bOoJ4-CQ"/>
@@ -9202,75 +9364,75 @@
       <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_vA0YFUJdEe6tO8bOoJ4-CQ" id="(1.0,0.7117437722419929)"/>
       <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_vA0YFkJdEe6tO8bOoJ4-CQ" id="(0.0,0.5)"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_0tUlJGnCEe6M0MEaxCUWiQ" type="StereotypeCommentLink" source="_vAqk8EJdEe6tO8bOoJ4-CQ" target="_0tUlIGnCEe6M0MEaxCUWiQ">
-      <styles xsi:type="notation:FontStyle" xmi:id="_0tUlJWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_0tUlKWnCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_yD8S4XfKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_vAqk8EJdEe6tO8bOoJ4-CQ" target="_yD7r0HfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_yD8S4nfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_yD8S5nfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiGnmiStreaming.uml#_406Q8KFhEe2n-fmfRwdlPg"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_0tUlJmnCEe6M0MEaxCUWiQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_0tUlJ2nCEe6M0MEaxCUWiQ"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_0tUlKGnCEe6M0MEaxCUWiQ"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_yD8S43fKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_yD8S5HfKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_yD8S5XfKEe6iN6ao8wePZw"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_0uQZRGnCEe6M0MEaxCUWiQ" type="StereotypeCommentLink" source="_vAqoRkJdEe6tO8bOoJ4-CQ" target="_0uQZQGnCEe6M0MEaxCUWiQ">
-      <styles xsi:type="notation:FontStyle" xmi:id="_0uQZRWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_0uQZSWnCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_yEwyRHfKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_vAqoRkJdEe6tO8bOoJ4-CQ" target="_yEwyQHfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_yEwyRXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_yEwySXfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiOam.uml#_-2fMYF0KEeipas1p-rFJBA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_0uQZRmnCEe6M0MEaxCUWiQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_0uQZR2nCEe6M0MEaxCUWiQ"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_0uQZSGnCEe6M0MEaxCUWiQ"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_yEwyRnfKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_yEwyR3fKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_yEwySHfKEe6iN6ao8wePZw"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_0vcsEWnCEe6M0MEaxCUWiQ" type="StereotypeCommentLink" source="_vA0WRUJdEe6tO8bOoJ4-CQ" target="_0vcFAGnCEe6M0MEaxCUWiQ">
-      <styles xsi:type="notation:FontStyle" xmi:id="_0vcsEmnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_0vcsFmnCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_yFubkXfKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_vA0WRUJdEe6tO8bOoJ4-CQ" target="_yFt0gHfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_yFubknfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_yFublnfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiOam.uml#_k-OoENzEEeaMV83ubDcSig"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_0vcsE2nCEe6M0MEaxCUWiQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_0vcsFGnCEe6M0MEaxCUWiQ"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_0vcsFWnCEe6M0MEaxCUWiQ"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_yFubk3fKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_yFublHfKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_yFublXfKEe6iN6ao8wePZw"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_0wDwEWnCEe6M0MEaxCUWiQ" type="StereotypeCommentLink" source="_vA0WhkJdEe6tO8bOoJ4-CQ" target="_0wDJAGnCEe6M0MEaxCUWiQ">
-      <styles xsi:type="notation:FontStyle" xmi:id="_0wDwEmnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_0wDwFmnCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_yGLukHfKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_vA0WhkJdEe6tO8bOoJ4-CQ" target="_yGLHgHfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_yGLukXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_yGLulXfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiConnectivity.uml#_oC2ZEEG_EeWAMMFKXSVi-w"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_0wDwE2nCEe6M0MEaxCUWiQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_0wDwFGnCEe6M0MEaxCUWiQ"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_0wDwFWnCEe6M0MEaxCUWiQ"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_yGLuknfKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_yGLuk3fKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_yGLulHfKEe6iN6ao8wePZw"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_0wrbJGnCEe6M0MEaxCUWiQ" type="StereotypeCommentLink" source="_vA0XMUJdEe6tO8bOoJ4-CQ" target="_0wrbIGnCEe6M0MEaxCUWiQ">
-      <styles xsi:type="notation:FontStyle" xmi:id="_0wrbJWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_0wsCMGnCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_yGi69HfKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_vA0XMUJdEe6tO8bOoJ4-CQ" target="_yGi68HfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_yGi69XfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_yGi6-XfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiOam.uml#_RRNb8DU7Eem_pr37XaewKQ"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_0wrbJmnCEe6M0MEaxCUWiQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_0wrbJ2nCEe6M0MEaxCUWiQ"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_0wrbKGnCEe6M0MEaxCUWiQ"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_yGi69nfKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_yGi693fKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_yGi6-HfKEe6iN6ao8wePZw"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_0xy1dGnCEe6M0MEaxCUWiQ" type="StereotypeCommentLink" source="_vA0YF0JdEe6tO8bOoJ4-CQ" target="_0xy1cGnCEe6M0MEaxCUWiQ">
-      <styles xsi:type="notation:FontStyle" xmi:id="_0xy1dWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_0xy1eWnCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_yHQFkHfKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_vA0YF0JdEe6tO8bOoJ4-CQ" target="_yHPegHfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_yHQFkXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_yHQFlXfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiOam.uml#_vnyfgF0IEeipas1p-rFJBA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_0xy1dmnCEe6M0MEaxCUWiQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_0xy1d2nCEe6M0MEaxCUWiQ"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_0xy1eGnCEe6M0MEaxCUWiQ"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_yHQFknfKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_yHQFk3fKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_yHQFlHfKEe6iN6ao8wePZw"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_0zmzUGnCEe6M0MEaxCUWiQ" type="StereotypeCommentLink" source="_vA0a8kJdEe6tO8bOoJ4-CQ" target="_0zmMQGnCEe6M0MEaxCUWiQ">
-      <styles xsi:type="notation:FontStyle" xmi:id="_0zmzUWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_0zmzVWnCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
+    <edges xsi:type="notation:Connector" xmi:id="_yIjtIXfKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_vA0a8kJdEe6tO8bOoJ4-CQ" target="_yIjGEHfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_yIjtInfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_yIjtJnfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
         <eObjectValue href="TapiOam.uml#_CE0kkLwmEeSpn78DYJKtkA"/>
       </styles>
       <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_0zmzUmnCEe6M0MEaxCUWiQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_0zmzU2nCEe6M0MEaxCUWiQ"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_0zmzVGnCEe6M0MEaxCUWiQ"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_yIjtI3fKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_yIjtJHfKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_yIjtJXfKEe6iN6ao8wePZw"/>
     </edges>
   </notation:Diagram>
   <notation:Diagram xmi:id="_c-ZM8EcsEe6bIJjw8ZnZGQ" type="PapyrusUMLClassDiagram" name="DataTypes" measurementUnit="Pixel">
@@ -9546,230 +9708,266 @@
         <layoutConstraint xsi:type="notation:Location" xmi:id="__k2Dl0csEe6bIJjw8ZnZGQ" y="15"/>
       </children>
       <children xsi:type="notation:BasicCompartment" xmi:id="__k2DmEcsEe6bIJjw8ZnZGQ" type="Enumeration_LiteralCompartment">
-        <children xsi:type="notation:Shape" xmi:id="__k2DmUcsEe6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="__k2DmkcsEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="__k2Dm0csEe6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="__k2DnEcsEe6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="__k2DnUcsEe6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_IlODQHfSEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_P6tDEHfSEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_P6tDEXfSEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_P6zwwnfSEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_P63bJXfSEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
           <element href="TapiCommon.uml#_-gM0AEyXEe2yGsF8121Sxw"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="__k2DnkcsEe6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_IlODQXfSEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="__k2Dn0csEe6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="__k2DoEcsEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="__k2DoUcsEe6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="__k2DokcsEe6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="__k2Do0csEe6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_IlPRYHfSEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_P6tqIHfSEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_P6tqIXfSEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_P6zww3fSEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_P63bJnfSEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
           <element href="TapiCommon.uml#_f5RJMJUgEe2x3INiJyRnZg"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="__k2DpEcsEe6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_IlPRYXfSEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="__k2DpUcsEe6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="__k2DpkcsEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="__k2Dp0csEe6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="__k2DqEcsEe6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="__k2DqUcsEe6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_IlP4cHfSEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_P6tqInfSEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_P6tqI3fSEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_P60X0HfSEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_P64CMHfSEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
           <element href="TapiCommon.uml#_-gThsEyXEe2yGsF8121Sxw"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="__k2DqkcsEe6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_IlP4cXfSEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="__k2Dq0csEe6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="__k2DrEcsEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="__k2DrUcsEe6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="__k2DrkcsEe6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="__k2Dr0csEe6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_IlQfgHfSEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_P6tqJHfSEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_P6tqJXfSEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_P60X0XfSEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_P64CMXfSEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
           <element href="TapiCommon.uml#_n3Bp8JUgEe2x3INiJyRnZg"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="__k2DsEcsEe6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_IlQfgXfSEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="__k2DsUcsEe6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="__k2DskcsEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="__k2Ds0csEe6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="__k2DtEcsEe6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="__k2DtUcsEe6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_IlQfgnfSEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_P6uRMHfSEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_P6uRMXfSEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_P60X0nfSEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_P64CMnfSEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
           <element href="TapiCommon.uml#_YK5UACyZEe6nUqp56BHaLA"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="__k2DtkcsEe6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_IlQfg3fSEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="__k2Dt0csEe6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="__k2DuEcsEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="__k2DuUcsEe6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="__k2DukcsEe6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="__k2Du0csEe6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_IlRGkHfSEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_P6uRMnfSEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_P6uRM3fSEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_P60-4HfSEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_P64CM3fSEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
           <element href="TapiCommon.uml#_zE4OMCyZEe6nUqp56BHaLA"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="__k2DvEcsEe6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_IlRGkXfSEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="__k2DvUcsEe6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="__k2DvkcsEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="__k2Dv0csEe6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="__k2DwEcsEe6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="__k2DwUcsEe6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_IlRGknfSEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_P6uRNHfSEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_P6uRNXfSEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_P60-4XfSEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_P64CNHfSEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
           <element href="TapiCommon.uml#_QpLrgCyYEe6nUqp56BHaLA"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="__k2DwkcsEe6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_IlRGk3fSEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="__k2Dw0csEe6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="__k2DxEcsEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="__k2DxUcsEe6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="__k2DxkcsEe6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="__k2Dx0csEe6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_IlRtoHfSEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_P6u4QHfSEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_P6u4QXfSEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_P60-4nfSEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_P64pQHfSEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
           <element href="TapiCommon.uml#_8GIowCyYEe6nUqp56BHaLA"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="__k2DyEcsEe6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_IlRtoXfSEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="__k2DyUcsEe6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="__k2DykcsEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="__k2Dy0csEe6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="__k2DzEcsEe6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="__k2DzUcsEe6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_IlRtonfSEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_P6u4QnfSEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_P6u4Q3fSEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_P60-43fSEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_P64pQXfSEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
           <element href="TapiCommon.uml#_-gVW4EyXEe2yGsF8121Sxw"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="__k2DzkcsEe6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_IlRto3fSEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="__k2Dz0csEe6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="__k2D0EcsEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="__k2D0UcsEe6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="__k2D0kcsEe6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="__k2D00csEe6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_IlRtpHfSEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_P6u4RHfSEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_P6u4RXfSEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_P61l8HfSEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_P64pQnfSEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
           <element href="TapiCommon.uml#_3KWgsCyXEe6nUqp56BHaLA"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="__k2D1EcsEe6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_IlRtpXfSEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="__k2D1UcsEe6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="__k2D1kcsEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="__k2D10csEe6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="__k2D2EcsEe6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="__k2D2UcsEe6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_IlSUsHfSEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_P6u4RnfSEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_P6u4R3fSEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_P61l8XfSEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_P64pQ3fSEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
           <element href="TapiCommon.uml#_UprCQCyUEe6nUqp56BHaLA"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="__k2D2kcsEe6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_IlSUsXfSEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="__k2D20csEe6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="__k2D3EcsEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="__k2D3UcsEe6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="__k2D3kcsEe6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="__k2D30csEe6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_IlSUsnfSEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_P6vfUHfSEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_P6vfUXfSEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_P61l8nfSEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_P64pRHfSEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
           <element href="TapiCommon.uml#_mbkZwCyYEe6nUqp56BHaLA"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="__k2D4EcsEe6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_IlSUs3fSEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="__k2D4UcsEe6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="__k2D4kcsEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="__k2D40csEe6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="__k2D5EcsEe6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="__k2D5UcsEe6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_IlSUtHfSEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_P6vfUnfSEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_P6vfU3fSEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_P61l83fSEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_P64pRXfSEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
           <element href="TapiCommon.uml#_-WsyoCyXEe6nUqp56BHaLA"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="__k2D5kcsEe6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_IlSUtXfSEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="__k2D50csEe6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="__k2D6EcsEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="__k2D6UcsEe6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="__k2D6kcsEe6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="__k2D60csEe6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_IlS7wHfSEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_P6vfVHfSEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_P6vfVXfSEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_P61l9HfSEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_P65QUHfSEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
           <element href="TapiCommon.uml#_UxzRQCyZEe6nUqp56BHaLA"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="__k2D7EcsEe6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_IlS7wXfSEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="__k2D7UcsEe6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="__k2D7kcsEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="__k2D70csEe6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="__k2D8EcsEe6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="__k2D8UcsEe6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_IlS7wnfSEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_P6vfVnfSEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_P6vfV3fSEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_P61l9XfSEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_P65QUXfSEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
           <element href="TapiCommon.uml#_DvsQkCyYEe6nUqp56BHaLA"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="__k2D8kcsEe6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_IlS7w3fSEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="__k2D80csEe6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="__k2D9EcsEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="__k2D9UcsEe6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="__k2D9kcsEe6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="__k2D90csEe6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_IlTi0HfSEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_P6wGYHfSEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_P6wGYXfSEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_P62NAHfSEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_P65QUnfSEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
           <element href="TapiCommon.uml#_m2-4gCyaEe6nUqp56BHaLA"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="__k2D-EcsEe6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_IlTi0XfSEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="__k2D-UcsEe6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="__k2D-kcsEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="__k2D-0csEe6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="__k2D_EcsEe6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="__k2D_UcsEe6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_IlTi0nfSEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_P6wGYnfSEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_P6wGY3fSEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_P62NAXfSEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_P65QU3fSEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
           <element href="TapiCommon.uml#_yQ0JcCyYEe6nUqp56BHaLA"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="__k2D_kcsEe6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_IlTi03fSEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="__k2D_0csEe6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="__k2EAEcsEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="__k2EAUcsEe6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="__k2EAkcsEe6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="__k2EA0csEe6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_IlUJ4HfSEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_P6wGZHfSEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_P6wGZXfSEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_P62NAnfSEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_P65QVHfSEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
           <element href="TapiCommon.uml#_rk0xYJUgEe2x3INiJyRnZg"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="__k2EBEcsEe6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_IlUJ4XfSEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="__k2EBUcsEe6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="__k2EBkcsEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="__k2EB0csEe6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="__k2ECEcsEe6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="__k2ECUcsEe6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_IlUw8HfSEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_P6wtcHfSEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_P6wtcXfSEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_P62NA3fSEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_P65QVXfSEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
           <element href="TapiCommon.uml#_L-NsoJKGEe2zcM0SMtXEHg"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="__k2ECkcsEe6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_IlUw8XfSEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="__k2EC0csEe6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="__k2EDEcsEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="__k2EDUcsEe6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="__k2EDkcsEe6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="__k2ED0csEe6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_IlVYAHfSEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_P6wtcnfSEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_P6wtc3fSEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_P620EHfSEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_P65QVnfSEe6iN6ao8wePZw" key="fontColor" value="true"/>
+          </eAnnotations>
+          <element href="TapiCommon.uml#_5LiwwENeEe6kK8KhUj-djw"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_IlVYAXfSEe6iN6ao8wePZw"/>
+        </children>
+        <children xsi:type="notation:Shape" xmi:id="_IlV_EHfSEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_P6xUgHfSEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_P6xUgXfSEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_P620EXfSEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_P65QV3fSEe6iN6ao8wePZw" key="fontColor" value="true"/>
+          </eAnnotations>
+          <element href="TapiCommon.uml#_6y4iAENeEe6kK8KhUj-djw"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_IlV_EXfSEe6iN6ao8wePZw"/>
+        </children>
+        <children xsi:type="notation:Shape" xmi:id="_IlV_EnfSEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_P6xUgnfSEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_P6xUg3fSEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_P620EnfSEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_P653YHfSEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
           <element href="TapiCommon.uml#_KAe0oJKGEe2zcM0SMtXEHg"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="__k2EEEcsEe6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_IlV_E3fSEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="__k2EEUcsEe6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="__k2EEkcsEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="__k2EE0csEe6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="__k2EFEcsEe6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="__k2EFUcsEe6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_IlWmIHfSEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_P6x7kHfSEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_P6x7kXfSEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_P620E3fSEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_P653YXfSEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
           <element href="TapiCommon.uml#_E9UjUJUkEe2x3INiJyRnZg"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="__k2EFkcsEe6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_IlWmIXfSEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="__k2EF0csEe6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="__k2EGEcsEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="__k2EGUcsEe6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="__k2EGkcsEe6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="__k2EG0csEe6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_IlWmInfSEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_P6x7knfSEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_P6x7k3fSEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_P620FHfSEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_P653YnfSEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
           <element href="TapiCommon.uml#_OAnCMJKGEe2zcM0SMtXEHg"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="__k2EHEcsEe6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_IlWmI3fSEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="__k2EHUcsEe6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="__k2EHkcsEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="__k2EH0csEe6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="__k2EIEcsEe6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="__k2EIUcsEe6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_IlWmJHfSEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_P6yioHfSEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_P6yioXfSEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_P63bIHfSEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_P653Y3fSEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
           <element href="TapiCommon.uml#_c9kNEJUgEe2x3INiJyRnZg"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="__k2EIkcsEe6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_IlXNMHfSEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="__k2EI0csEe6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="__k2EJEcsEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="__k2EJUcsEe6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="__k2EJkcsEe6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="__k2EJ0csEe6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_IlXNMXfSEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_P6yionfSEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_P6yio3fSEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_P63bIXfSEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_P653ZHfSEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
           <element href="TapiCommon.uml#_-gWlAEyXEe2yGsF8121Sxw"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="__k2EKEcsEe6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_IlXNMnfSEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="__k2EKUcsEe6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="__k2EKkcsEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="__k2EK0csEe6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="__k2ELEcsEe6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="__k2ELUcsEe6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_IlXNM3fSEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_P6zJsHfSEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_P6zJsXfSEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_P63bInfSEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_P653ZXfSEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
           <element href="TapiCommon.uml#_-gbdgEyXEe2yGsF8121Sxw"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="__k2ELkcsEe6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_IlXNNHfSEe6iN6ao8wePZw"/>
+        </children>
+        <children xsi:type="notation:Shape" xmi:id="_IlXNNXfSEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_P6zJsnfSEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_P6zJs3fSEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_P63bI3fSEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_P653ZnfSEe6iN6ao8wePZw" key="fontColor" value="true"/>
+          </eAnnotations>
+          <element href="TapiCommon.uml#_F11SEENfEe6kK8KhUj-djw"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_IlXNNnfSEe6iN6ao8wePZw"/>
+        </children>
+        <children xsi:type="notation:Shape" xmi:id="_IlYbUHfSEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_P6zwwHfSEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_P6zwwXfSEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_P63bJHfSEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_P66ecHfSEe6iN6ao8wePZw" key="fontColor" value="true"/>
+          </eAnnotations>
+          <element href="TapiCommon.uml#_HfleIENfEe6kK8KhUj-djw"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_IlYbUXfSEe6iN6ao8wePZw"/>
         </children>
         <styles xsi:type="notation:TitleStyle" xmi:id="__k2EL0csEe6bIJjw8ZnZGQ"/>
         <styles xsi:type="notation:SortingStyle" xmi:id="__k2EMEcsEe6bIJjw8ZnZGQ"/>
@@ -9777,7 +9975,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="__k2EMkcsEe6bIJjw8ZnZGQ"/>
       </children>
       <element href="TapiCommon.uml#_xnfcMEyXEe2yGsF8121Sxw"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="__k2ENkcsEe6bIJjw8ZnZGQ" x="1780" y="140" width="241" height="441"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="__k2ENkcsEe6bIJjw8ZnZGQ" x="1780" y="140" width="241" height="561"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="__k2EN0csEe6bIJjw8ZnZGQ" type="Enumeration_Shape" fontName="Segoe UI" fontHeight="6" fillColor="8905185">
       <eAnnotations xmi:id="__k2EOEcsEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
@@ -9793,6 +9991,24 @@
         <layoutConstraint xsi:type="notation:Location" xmi:id="__k2EPkcsEe6bIJjw8ZnZGQ" y="15"/>
       </children>
       <children xsi:type="notation:BasicCompartment" xmi:id="__k2EP0csEe6bIJjw8ZnZGQ" type="Enumeration_LiteralCompartment">
+        <children xsi:type="notation:Shape" xmi:id="_7_6MwHfKEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_Fv6HMHfLEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_Fv6uQHfLEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_Fv7VUHfLEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_Fv78YHfLEe6iN6ao8wePZw" key="fontColor" value="true"/>
+          </eAnnotations>
+          <children xsi:type="notation:BasicCompartment" xmi:id="_8An-cHfKEe6iN6ao8wePZw" type="StereotypeBrace">
+            <eAnnotations xmi:id="_C9OkMHfLEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+              <details xmi:id="_C9PLQHfLEe6iN6ao8wePZw" key="visible" value="true"/>
+            </eAnnotations>
+            <styles xsi:type="notation:TitleStyle" xmi:id="_8An-cXfKEe6iN6ao8wePZw"/>
+            <styles xsi:type="notation:StringValueStyle" xmi:id="_8An-cnfKEe6iN6ao8wePZw" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
+            <element href="UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_6vylQKZvEe2n-fmfRwdlPg"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_8An-c3fKEe6iN6ao8wePZw"/>
+          </children>
+          <element href="TapiGnmiStreaming.uml#_lH_CwHcaEe6iN6ao8wePZw"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_7_6MwXfKEe6iN6ao8wePZw"/>
+        </children>
         <children xsi:type="notation:Shape" xmi:id="__k2EQEcsEe6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
           <eAnnotations xmi:id="__k2EQUcsEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
             <details xmi:id="__k2EQkcsEe6bIJjw8ZnZGQ" key="bold" value="true"/>
@@ -9872,7 +10088,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="__k2Eh0csEe6bIJjw8ZnZGQ"/>
       </children>
       <element href="TapiGnmiStreaming.uml#_nwJQkKYQEe2n-fmfRwdlPg"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="__k2Ei0csEe6bIJjw8ZnZGQ" x="60" y="260" width="241" height="121"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="__k2Ei0csEe6bIJjw8ZnZGQ" x="60" y="260" width="241" height="141"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="__k2qoEcsEe6bIJjw8ZnZGQ" type="Enumeration_Shape" fontName="Segoe UI" fontHeight="6" fillColor="8905185">
       <eAnnotations xmi:id="__k2qoUcsEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
@@ -9980,455 +10196,545 @@
         <layoutConstraint xsi:type="notation:Location" xmi:id="__k2q_EcsEe6bIJjw8ZnZGQ" y="15"/>
       </children>
       <children xsi:type="notation:BasicCompartment" xmi:id="__k2q_UcsEe6bIJjw8ZnZGQ" type="Enumeration_LiteralCompartment">
-        <children xsi:type="notation:Shape" xmi:id="__k2q_kcsEe6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="__k2q_0csEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="__k2rAEcsEe6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="__k2rAUcsEe6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="__k2rAkcsEe6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_9WJQ0HfTEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_RujUYHfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_RujUYXfUEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_RumXsnfUEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_RuoM5XfUEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
-          <children xsi:type="notation:BasicCompartment" xmi:id="_QhZZbEcvEe6bIJjw8ZnZGQ" type="StereotypeBrace">
-            <eAnnotations xmi:id="_qfPbcEcvEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-              <details xmi:id="_qfPbcUcvEe6bIJjw8ZnZGQ" key="visible" value="true"/>
+          <children xsi:type="notation:BasicCompartment" xmi:id="_9W9wM3fTEe6iN6ao8wePZw" type="StereotypeBrace">
+            <eAnnotations xmi:id="_VNSFEHfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+              <details xmi:id="_VNSFEXfUEe6iN6ao8wePZw" key="visible" value="true"/>
             </eAnnotations>
-            <styles xsi:type="notation:TitleStyle" xmi:id="_QhZZbUcvEe6bIJjw8ZnZGQ"/>
-            <styles xsi:type="notation:StringValueStyle" xmi:id="_QhZZbkcvEe6bIJjw8ZnZGQ" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
+            <styles xsi:type="notation:TitleStyle" xmi:id="_9W9wNHfTEe6iN6ao8wePZw"/>
+            <styles xsi:type="notation:StringValueStyle" xmi:id="_9W9wNXfTEe6iN6ao8wePZw" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
             <element href="UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_6vylQKZvEe2n-fmfRwdlPg"/>
-            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_QhZZb0cvEe6bIJjw8ZnZGQ"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_9W9wNnfTEe6iN6ao8wePZw"/>
+          </children>
+          <element href="TapiGnmiStreaming.uml#_RpcNIHcfEe6iN6ao8wePZw"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_9WJQ0XfTEe6iN6ao8wePZw"/>
+        </children>
+        <children xsi:type="notation:Shape" xmi:id="_9WLGAHfTEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_RujUYnfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_RujUY3fUEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_RumXs3fUEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_RuoM5nfUEe6iN6ao8wePZw" key="fontColor" value="true"/>
+          </eAnnotations>
+          <children xsi:type="notation:BasicCompartment" xmi:id="_9XCBoHfTEe6iN6ao8wePZw" type="StereotypeBrace">
+            <eAnnotations xmi:id="_Vq_UwHfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+              <details xmi:id="_Vq_UwXfUEe6iN6ao8wePZw" key="visible" value="true"/>
+            </eAnnotations>
+            <styles xsi:type="notation:TitleStyle" xmi:id="_9XCBoXfTEe6iN6ao8wePZw"/>
+            <styles xsi:type="notation:StringValueStyle" xmi:id="_9XCBonfTEe6iN6ao8wePZw" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
+            <element href="UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_6vylQKZvEe2n-fmfRwdlPg"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_9XCBo3fTEe6iN6ao8wePZw"/>
           </children>
           <element href="TapiGnmiStreaming.uml#__6_sAUcnEe6bIJjw8ZnZGQ"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="__k2rA0csEe6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_9WLGAXfTEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="__k2rBEcsEe6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="__k2rBUcsEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="__k2rBkcsEe6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="__k2rB0csEe6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="__k2rCEcsEe6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_9WLtEHfTEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_Ruj7cHfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_Ruj7cXfUEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_RumXtHfUEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_RuoM53fUEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
-          <children xsi:type="notation:BasicCompartment" xmi:id="_UWFL_EcvEe6bIJjw8ZnZGQ" type="StereotypeBrace">
-            <eAnnotations xmi:id="_DSmx8EcxEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-              <details xmi:id="_DSmx8UcxEe6bIJjw8ZnZGQ" key="visible" value="true"/>
+          <children xsi:type="notation:BasicCompartment" xmi:id="_9XG6I3fTEe6iN6ao8wePZw" type="StereotypeBrace">
+            <eAnnotations xmi:id="_WIz5MHfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+              <details xmi:id="_WIz5MXfUEe6iN6ao8wePZw" key="visible" value="true"/>
             </eAnnotations>
-            <styles xsi:type="notation:TitleStyle" xmi:id="_UWFL_UcvEe6bIJjw8ZnZGQ"/>
-            <styles xsi:type="notation:StringValueStyle" xmi:id="_UWFL_kcvEe6bIJjw8ZnZGQ" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
+            <styles xsi:type="notation:TitleStyle" xmi:id="_9XG6JHfTEe6iN6ao8wePZw"/>
+            <styles xsi:type="notation:StringValueStyle" xmi:id="_9XG6JXfTEe6iN6ao8wePZw" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
             <element href="UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_6vylQKZvEe2n-fmfRwdlPg"/>
-            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_UWFL_0cvEe6bIJjw8ZnZGQ"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_9XG6JnfTEe6iN6ao8wePZw"/>
           </children>
           <element href="TapiGnmiStreaming.uml#__6_sAkcnEe6bIJjw8ZnZGQ"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="__k2rCUcsEe6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_9WLtEXfTEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="__k2rCkcsEe6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="__k2rC0csEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="__k2rDEcsEe6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="__k2rDUcsEe6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="__k2rDkcsEe6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_9WMUIHfTEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_Ruj7cnfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_Ruj7c3fUEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_RumXtXfUEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_RuoM6HfUEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
-          <children xsi:type="notation:BasicCompartment" xmi:id="_auC-JUcwEe6bIJjw8ZnZGQ" type="StereotypeBrace">
-            <eAnnotations xmi:id="_Dr4NkEcxEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-              <details xmi:id="_Dr4NkUcxEe6bIJjw8ZnZGQ" key="visible" value="true"/>
+          <children xsi:type="notation:BasicCompartment" xmi:id="_9XJ9cHfTEe6iN6ao8wePZw" type="StereotypeBrace">
+            <eAnnotations xmi:id="_WiEtwHfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+              <details xmi:id="_WiEtwXfUEe6iN6ao8wePZw" key="visible" value="true"/>
             </eAnnotations>
-            <styles xsi:type="notation:TitleStyle" xmi:id="_auC-JkcwEe6bIJjw8ZnZGQ"/>
-            <styles xsi:type="notation:StringValueStyle" xmi:id="_auC-J0cwEe6bIJjw8ZnZGQ" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
+            <styles xsi:type="notation:TitleStyle" xmi:id="_9XJ9cXfTEe6iN6ao8wePZw"/>
+            <styles xsi:type="notation:StringValueStyle" xmi:id="_9XJ9cnfTEe6iN6ao8wePZw" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
             <element href="UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_6vylQKZvEe2n-fmfRwdlPg"/>
-            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_auC-KEcwEe6bIJjw8ZnZGQ"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_9XJ9c3fTEe6iN6ao8wePZw"/>
           </children>
           <element href="TapiGnmiStreaming.uml#__6_sBEcnEe6bIJjw8ZnZGQ"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="__k2rD0csEe6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_9WM7MHfTEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="__k2rEEcsEe6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="__k2rEUcsEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="__k2rEkcsEe6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="__k2rE0csEe6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="__k2rFEcsEe6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_9WNiQHfTEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_Ruj7dHfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_Ruj7dXfUEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_RumXtnfUEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_Ruoz8HfUEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
-          <children xsi:type="notation:BasicCompartment" xmi:id="_ebbO1UcwEe6bIJjw8ZnZGQ" type="StereotypeBrace">
-            <eAnnotations xmi:id="_EZwnQEcxEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-              <details xmi:id="_EZwnQUcxEe6bIJjw8ZnZGQ" key="visible" value="true"/>
+          <children xsi:type="notation:BasicCompartment" xmi:id="_9XMZs3fTEe6iN6ao8wePZw" type="StereotypeBrace">
+            <eAnnotations xmi:id="_W7tVwHfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+              <details xmi:id="_W7tVwXfUEe6iN6ao8wePZw" key="visible" value="true"/>
             </eAnnotations>
-            <styles xsi:type="notation:TitleStyle" xmi:id="_ebbO1kcwEe6bIJjw8ZnZGQ"/>
-            <styles xsi:type="notation:StringValueStyle" xmi:id="_ebbO10cwEe6bIJjw8ZnZGQ" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
+            <styles xsi:type="notation:TitleStyle" xmi:id="_9XMZtHfTEe6iN6ao8wePZw"/>
+            <styles xsi:type="notation:StringValueStyle" xmi:id="_9XMZtXfTEe6iN6ao8wePZw" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
             <element href="UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_6vylQKZvEe2n-fmfRwdlPg"/>
-            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_ebbO2EcwEe6bIJjw8ZnZGQ"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_9XMZtnfTEe6iN6ao8wePZw"/>
           </children>
           <element href="TapiGnmiStreaming.uml#__6_sBUcnEe6bIJjw8ZnZGQ"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="__k2rFUcsEe6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_9WNiQXfTEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="__k2rFkcsEe6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="__k2rF0csEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="__k2rGEcsEe6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="__k2rGUcsEe6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="__k2rGkcsEe6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_9WOJUHfTEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_Ruj7dnfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_Ruj7d3fUEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_RumXt3fUEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_Ruoz8XfUEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
-          <children xsi:type="notation:BasicCompartment" xmi:id="_k_5odUcwEe6bIJjw8ZnZGQ" type="StereotypeBrace">
-            <eAnnotations xmi:id="_ElZ2kEcxEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-              <details xmi:id="_ElZ2kUcxEe6bIJjw8ZnZGQ" key="visible" value="true"/>
+          <children xsi:type="notation:BasicCompartment" xmi:id="_9XPdA3fTEe6iN6ao8wePZw" type="StereotypeBrace">
+            <eAnnotations xmi:id="_XUPKgHfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+              <details xmi:id="_XUPKgXfUEe6iN6ao8wePZw" key="visible" value="true"/>
             </eAnnotations>
-            <styles xsi:type="notation:TitleStyle" xmi:id="_k_5odkcwEe6bIJjw8ZnZGQ"/>
-            <styles xsi:type="notation:StringValueStyle" xmi:id="_k_5od0cwEe6bIJjw8ZnZGQ" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
+            <styles xsi:type="notation:TitleStyle" xmi:id="_9XPdBHfTEe6iN6ao8wePZw"/>
+            <styles xsi:type="notation:StringValueStyle" xmi:id="_9XPdBXfTEe6iN6ao8wePZw" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
             <element href="UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_6vylQKZvEe2n-fmfRwdlPg"/>
-            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_k_5oeEcwEe6bIJjw8ZnZGQ"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_9XPdBnfTEe6iN6ao8wePZw"/>
           </children>
           <element href="TapiGnmiStreaming.uml#__6_sB0cnEe6bIJjw8ZnZGQ"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="__k2rG0csEe6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_9WOJUXfTEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="__k2rHEcsEe6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="__k2rHUcsEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="__k2rHkcsEe6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="__k2rH0csEe6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="__k2rIEcsEe6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_9WOJUnfTEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_Ruj7eHfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_Ruj7eXfUEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_RumXuHfUEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_Ruoz8nfUEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
-          <children xsi:type="notation:BasicCompartment" xmi:id="_orw2M0cwEe6bIJjw8ZnZGQ" type="StereotypeBrace">
-            <eAnnotations xmi:id="_EyeCMEcxEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-              <details xmi:id="_EyeCMUcxEe6bIJjw8ZnZGQ" key="visible" value="true"/>
+          <children xsi:type="notation:BasicCompartment" xmi:id="_9XTHYHfTEe6iN6ao8wePZw" type="StereotypeBrace">
+            <eAnnotations xmi:id="_Xt3LcHfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+              <details xmi:id="_Xt3LcXfUEe6iN6ao8wePZw" key="visible" value="true"/>
             </eAnnotations>
-            <styles xsi:type="notation:TitleStyle" xmi:id="_orw2NEcwEe6bIJjw8ZnZGQ"/>
-            <styles xsi:type="notation:StringValueStyle" xmi:id="_orw2NUcwEe6bIJjw8ZnZGQ" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
+            <styles xsi:type="notation:TitleStyle" xmi:id="_9XTHYXfTEe6iN6ao8wePZw"/>
+            <styles xsi:type="notation:StringValueStyle" xmi:id="_9XTHYnfTEe6iN6ao8wePZw" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
             <element href="UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_6vylQKZvEe2n-fmfRwdlPg"/>
-            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_orw2NkcwEe6bIJjw8ZnZGQ"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_9XTHY3fTEe6iN6ao8wePZw"/>
           </children>
           <element href="TapiGnmiStreaming.uml#__6_sCUcnEe6bIJjw8ZnZGQ"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="__k2rIUcsEe6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_9WOJU3fTEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="__k2rIkcsEe6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="__k2rI0csEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="__k2rJEcsEe6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="__k2rJUcsEe6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="__k2rJkcsEe6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_9WOwYHfTEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_RukigHfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_RukigXfUEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_RumXuXfUEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_Ruoz83fUEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
-          <children xsi:type="notation:BasicCompartment" xmi:id="_upv3mkcwEe6bIJjw8ZnZGQ" type="StereotypeBrace">
-            <eAnnotations xmi:id="_FCCvQEcxEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-              <details xmi:id="_FCCvQUcxEe6bIJjw8ZnZGQ" key="visible" value="true"/>
+          <children xsi:type="notation:BasicCompartment" xmi:id="_9XWxw3fTEe6iN6ao8wePZw" type="StereotypeBrace">
+            <eAnnotations xmi:id="_YHsAsHfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+              <details xmi:id="_YHsAsXfUEe6iN6ao8wePZw" key="visible" value="true"/>
             </eAnnotations>
-            <styles xsi:type="notation:TitleStyle" xmi:id="_upv3m0cwEe6bIJjw8ZnZGQ"/>
-            <styles xsi:type="notation:StringValueStyle" xmi:id="_upv3nEcwEe6bIJjw8ZnZGQ" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
+            <styles xsi:type="notation:TitleStyle" xmi:id="_9XWxxHfTEe6iN6ao8wePZw"/>
+            <styles xsi:type="notation:StringValueStyle" xmi:id="_9XWxxXfTEe6iN6ao8wePZw" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
             <element href="UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_6vylQKZvEe2n-fmfRwdlPg"/>
-            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_upv3nUcwEe6bIJjw8ZnZGQ"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_9XWxxnfTEe6iN6ao8wePZw"/>
           </children>
           <element href="TapiGnmiStreaming.uml#__6_sC0cnEe6bIJjw8ZnZGQ"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="__k2rJ0csEe6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_9WOwYXfTEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="__k2rKEcsEe6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="__k2rKUcsEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="__k2rKkcsEe6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="__k2rK0csEe6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="__k2rLEcsEe6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_9WPXcHfTEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_RukignfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_Rukig3fUEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_Rum-wHfUEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_Ruoz9HfUEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
-          <children xsi:type="notation:BasicCompartment" xmi:id="_yVIkPEcwEe6bIJjw8ZnZGQ" type="StereotypeBrace">
-            <eAnnotations xmi:id="_GV_DYEcxEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-              <details xmi:id="_GV_DYUcxEe6bIJjw8ZnZGQ" key="visible" value="true"/>
+          <children xsi:type="notation:BasicCompartment" xmi:id="_9XbqQHfTEe6iN6ao8wePZw" type="StereotypeBrace">
+            <eAnnotations xmi:id="_YhIbcHfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+              <details xmi:id="_YhIbcXfUEe6iN6ao8wePZw" key="visible" value="true"/>
             </eAnnotations>
-            <styles xsi:type="notation:TitleStyle" xmi:id="_yVIkPUcwEe6bIJjw8ZnZGQ"/>
-            <styles xsi:type="notation:StringValueStyle" xmi:id="_yVIkPkcwEe6bIJjw8ZnZGQ" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
+            <styles xsi:type="notation:TitleStyle" xmi:id="_9XbqQXfTEe6iN6ao8wePZw"/>
+            <styles xsi:type="notation:StringValueStyle" xmi:id="_9XbqQnfTEe6iN6ao8wePZw" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
             <element href="UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_6vylQKZvEe2n-fmfRwdlPg"/>
-            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_yVIkP0cwEe6bIJjw8ZnZGQ"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_9XbqQ3fTEe6iN6ao8wePZw"/>
           </children>
           <element href="TapiGnmiStreaming.uml#__6_sDUcnEe6bIJjw8ZnZGQ"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="__k2rLUcsEe6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_9WPXcXfTEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="__k2rLkcsEe6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="__k2rL0csEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="__k2rMEcsEe6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="__k2rMUcsEe6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="__k2rMkcsEe6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_9WP-gHfTEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_RukihHfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_RukihXfUEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_Rum-wXfUEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_Ruoz9XfUEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
-          <children xsi:type="notation:BasicCompartment" xmi:id="_23bDqUcwEe6bIJjw8ZnZGQ" type="StereotypeBrace">
-            <eAnnotations xmi:id="_Dfn6QEcxEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-              <details xmi:id="_Dfn6QUcxEe6bIJjw8ZnZGQ" key="visible" value="true"/>
+          <children xsi:type="notation:BasicCompartment" xmi:id="_9Xhw4HfTEe6iN6ao8wePZw" type="StereotypeBrace">
+            <eAnnotations xmi:id="_Y5tTgHfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+              <details xmi:id="_Y5tTgXfUEe6iN6ao8wePZw" key="visible" value="true"/>
             </eAnnotations>
-            <styles xsi:type="notation:TitleStyle" xmi:id="_23bDqkcwEe6bIJjw8ZnZGQ"/>
-            <styles xsi:type="notation:StringValueStyle" xmi:id="_23bDq0cwEe6bIJjw8ZnZGQ" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
+            <styles xsi:type="notation:TitleStyle" xmi:id="_9Xhw4XfTEe6iN6ao8wePZw"/>
+            <styles xsi:type="notation:StringValueStyle" xmi:id="_9Xhw4nfTEe6iN6ao8wePZw" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
             <element href="UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_6vylQKZvEe2n-fmfRwdlPg"/>
-            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_23bDrEcwEe6bIJjw8ZnZGQ"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_9Xhw43fTEe6iN6ao8wePZw"/>
           </children>
           <element href="TapiGnmiStreaming.uml#__6_sD0cnEe6bIJjw8ZnZGQ"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="__k2rM0csEe6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_9WP-gXfTEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="__k2rNEcsEe6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="__k2rNUcsEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="__k2rNkcsEe6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="__k2rN0csEe6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="__k2rOEcsEe6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_9WP-gnfTEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_RukihnfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_Rukih3fUEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_Rum-wnfUEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_Ruoz9nfUEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
-          <children xsi:type="notation:BasicCompartment" xmi:id="_JQshDEcxEe6bIJjw8ZnZGQ" type="StereotypeBrace">
-            <eAnnotations xmi:id="_ykc9IEcxEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-              <details xmi:id="_ykc9IUcxEe6bIJjw8ZnZGQ" key="visible" value="true"/>
+          <children xsi:type="notation:BasicCompartment" xmi:id="_9XnQcHfTEe6iN6ao8wePZw" type="StereotypeBrace">
+            <eAnnotations xmi:id="_ZTVUcHfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+              <details xmi:id="_ZTV7gHfUEe6iN6ao8wePZw" key="visible" value="true"/>
             </eAnnotations>
-            <styles xsi:type="notation:TitleStyle" xmi:id="_JQshDUcxEe6bIJjw8ZnZGQ"/>
-            <styles xsi:type="notation:StringValueStyle" xmi:id="_JQshDkcxEe6bIJjw8ZnZGQ" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
+            <styles xsi:type="notation:TitleStyle" xmi:id="_9XnQcXfTEe6iN6ao8wePZw"/>
+            <styles xsi:type="notation:StringValueStyle" xmi:id="_9XnQcnfTEe6iN6ao8wePZw" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
             <element href="UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_6vylQKZvEe2n-fmfRwdlPg"/>
-            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_JQshD0cxEe6bIJjw8ZnZGQ"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_9XnQc3fTEe6iN6ao8wePZw"/>
           </children>
           <element href="TapiGnmiStreaming.uml#__6_sEUcnEe6bIJjw8ZnZGQ"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="__k2rOUcsEe6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_9WP-g3fTEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="__k2rOkcsEe6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="__k2rO0csEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="__k2rPEcsEe6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="__k2rPUcsEe6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="__k2rPkcsEe6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_9WQlkHfTEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_RukiiHfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_RukiiXfUEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_Rum-w3fUEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_Ruoz93fUEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
-          <children xsi:type="notation:BasicCompartment" xmi:id="_MpaJTEcxEe6bIJjw8ZnZGQ" type="StereotypeBrace">
-            <eAnnotations xmi:id="_yZEMgEcxEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-              <details xmi:id="_yZEMgUcxEe6bIJjw8ZnZGQ" key="visible" value="true"/>
+          <children xsi:type="notation:BasicCompartment" xmi:id="_9XqTw3fTEe6iN6ao8wePZw" type="StereotypeBrace">
+            <eAnnotations xmi:id="_c2ggQHfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+              <details xmi:id="_c2ggQXfUEe6iN6ao8wePZw" key="visible" value="true"/>
             </eAnnotations>
-            <styles xsi:type="notation:TitleStyle" xmi:id="_MpaJTUcxEe6bIJjw8ZnZGQ"/>
-            <styles xsi:type="notation:StringValueStyle" xmi:id="_MpaJTkcxEe6bIJjw8ZnZGQ" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
+            <styles xsi:type="notation:TitleStyle" xmi:id="_9XqTxHfTEe6iN6ao8wePZw"/>
+            <styles xsi:type="notation:StringValueStyle" xmi:id="_9XqTxXfTEe6iN6ao8wePZw" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
             <element href="UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_6vylQKZvEe2n-fmfRwdlPg"/>
-            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_MpaJT0cxEe6bIJjw8ZnZGQ"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_9XqTxnfTEe6iN6ao8wePZw"/>
           </children>
           <element href="TapiGnmiStreaming.uml#__6_sE0cnEe6bIJjw8ZnZGQ"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="__k2rP0csEe6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_9WQlkXfTEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="__k2rQEcsEe6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="__k2rQUcsEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="__k2rQkcsEe6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="__k2rQ0csEe6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="__k2rREcsEe6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_9WQlknfTEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_RukiinfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_Rukii3fUEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_Rum-xHfUEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_Ruoz-HfUEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
-          <children xsi:type="notation:BasicCompartment" xmi:id="_QD9knEcxEe6bIJjw8ZnZGQ" type="StereotypeBrace">
-            <eAnnotations xmi:id="_yMDrQEcxEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-              <details xmi:id="_yMDrQUcxEe6bIJjw8ZnZGQ" key="visible" value="true"/>
+          <children xsi:type="notation:BasicCompartment" xmi:id="_9XtXE3fTEe6iN6ao8wePZw" type="StereotypeBrace">
+            <eAnnotations xmi:id="_dQ1r0HfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+              <details xmi:id="_dQ1r0XfUEe6iN6ao8wePZw" key="visible" value="true"/>
             </eAnnotations>
-            <styles xsi:type="notation:TitleStyle" xmi:id="_QD9knUcxEe6bIJjw8ZnZGQ"/>
-            <styles xsi:type="notation:StringValueStyle" xmi:id="_QD9knkcxEe6bIJjw8ZnZGQ" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
+            <styles xsi:type="notation:TitleStyle" xmi:id="_9XtXFHfTEe6iN6ao8wePZw"/>
+            <styles xsi:type="notation:StringValueStyle" xmi:id="_9XtXFXfTEe6iN6ao8wePZw" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
             <element href="UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_6vylQKZvEe2n-fmfRwdlPg"/>
-            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_QD9kn0cxEe6bIJjw8ZnZGQ"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_9XtXFnfTEe6iN6ao8wePZw"/>
           </children>
           <element href="TapiGnmiStreaming.uml#__6_sFUcnEe6bIJjw8ZnZGQ"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="__k2rRUcsEe6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_9WQlk3fTEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="__k2rRkcsEe6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="__k2rR0csEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="__k2rSEcsEe6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="__k2rSUcsEe6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="__k2rSkcsEe6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_9WQllHfTEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_RulJkHfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_RulJkXfUEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_Rum-xXfUEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_Ruoz-XfUEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
-          <children xsi:type="notation:BasicCompartment" xmi:id="_U9Q13EcxEe6bIJjw8ZnZGQ" type="StereotypeBrace">
-            <eAnnotations xmi:id="_xeZ7EEcxEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-              <details xmi:id="_xeaiIEcxEe6bIJjw8ZnZGQ" key="visible" value="true"/>
+          <children xsi:type="notation:BasicCompartment" xmi:id="_9XwaY3fTEe6iN6ao8wePZw" type="StereotypeBrace">
+            <eAnnotations xmi:id="_dp0MgHfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+              <details xmi:id="_dp0MgXfUEe6iN6ao8wePZw" key="visible" value="true"/>
             </eAnnotations>
-            <styles xsi:type="notation:TitleStyle" xmi:id="_U9Q13UcxEe6bIJjw8ZnZGQ"/>
-            <styles xsi:type="notation:StringValueStyle" xmi:id="_U9Q13kcxEe6bIJjw8ZnZGQ" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
+            <styles xsi:type="notation:TitleStyle" xmi:id="_9XwaZHfTEe6iN6ao8wePZw"/>
+            <styles xsi:type="notation:StringValueStyle" xmi:id="_9XwaZXfTEe6iN6ao8wePZw" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
             <element href="UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_6vylQKZvEe2n-fmfRwdlPg"/>
-            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_U9Q130cxEe6bIJjw8ZnZGQ"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_9XwaZnfTEe6iN6ao8wePZw"/>
           </children>
           <element href="TapiGnmiStreaming.uml#__6_sF0cnEe6bIJjw8ZnZGQ"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="__k2rS0csEe6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_9WRMoHfTEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="__k2rTEcsEe6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="__k2rTUcsEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="__k2rTkcsEe6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="__k2rT0csEe6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="__k2rUEcsEe6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_9WRMoXfTEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_RulJknfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_RulJk3fUEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_Rum-xnfUEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_RupbAHfUEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
-          <children xsi:type="notation:BasicCompartment" xmi:id="_Ygr5RUcxEe6bIJjw8ZnZGQ" type="StereotypeBrace">
-            <eAnnotations xmi:id="_xQO8MEcxEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-              <details xmi:id="_xQO8MUcxEe6bIJjw8ZnZGQ" key="visible" value="true"/>
+          <children xsi:type="notation:BasicCompartment" xmi:id="_9Xzds3fTEe6iN6ao8wePZw" type="StereotypeBrace">
+            <eAnnotations xmi:id="_eD4SUHfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+              <details xmi:id="_eD4SUXfUEe6iN6ao8wePZw" key="visible" value="true"/>
             </eAnnotations>
-            <styles xsi:type="notation:TitleStyle" xmi:id="_Ygr5RkcxEe6bIJjw8ZnZGQ"/>
-            <styles xsi:type="notation:StringValueStyle" xmi:id="_Ygr5R0cxEe6bIJjw8ZnZGQ" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
+            <styles xsi:type="notation:TitleStyle" xmi:id="_9XzdtHfTEe6iN6ao8wePZw"/>
+            <styles xsi:type="notation:StringValueStyle" xmi:id="_9XzdtXfTEe6iN6ao8wePZw" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
             <element href="UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_6vylQKZvEe2n-fmfRwdlPg"/>
-            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_Ygr5SEcxEe6bIJjw8ZnZGQ"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_9XzdtnfTEe6iN6ao8wePZw"/>
           </children>
           <element href="TapiGnmiStreaming.uml#__6_sGUcnEe6bIJjw8ZnZGQ"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="__k2rUUcsEe6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_9WRMonfTEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="__k2rUkcsEe6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="__k2rU0csEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="__k2rVEcsEe6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="__k2rVUcsEe6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="__k2rVkcsEe6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_9WRzsHfTEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_RulJlHfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_RulJlXfUEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_Rum-x3fUEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_RupbAXfUEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
-          <children xsi:type="notation:BasicCompartment" xmi:id="_b4N1xUcxEe6bIJjw8ZnZGQ" type="StereotypeBrace">
-            <eAnnotations xmi:id="_xElF0EcxEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-              <details xmi:id="_xElF0UcxEe6bIJjw8ZnZGQ" key="visible" value="true"/>
+          <children xsi:type="notation:BasicCompartment" xmi:id="_9X2hA3fTEe6iN6ao8wePZw" type="StereotypeBrace">
+            <eAnnotations xmi:id="_efFAkHfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+              <details xmi:id="_efFnoHfUEe6iN6ao8wePZw" key="visible" value="true"/>
             </eAnnotations>
-            <styles xsi:type="notation:TitleStyle" xmi:id="_b4N1xkcxEe6bIJjw8ZnZGQ"/>
-            <styles xsi:type="notation:StringValueStyle" xmi:id="_b4N1x0cxEe6bIJjw8ZnZGQ" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
+            <styles xsi:type="notation:TitleStyle" xmi:id="_9X2hBHfTEe6iN6ao8wePZw"/>
+            <styles xsi:type="notation:StringValueStyle" xmi:id="_9X2hBXfTEe6iN6ao8wePZw" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
             <element href="UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_6vylQKZvEe2n-fmfRwdlPg"/>
-            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_b4N1yEcxEe6bIJjw8ZnZGQ"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_9X2hBnfTEe6iN6ao8wePZw"/>
           </children>
           <element href="TapiGnmiStreaming.uml#__6_sG0cnEe6bIJjw8ZnZGQ"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="__k2rV0csEe6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_9WRzsXfTEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="__k2rWEcsEe6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="__k2rWUcsEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="__k2rWkcsEe6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="__k2rW0csEe6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="__k2rXEcsEe6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_9WRzsnfTEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_RulJlnfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_RulJl3fUEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_Rum-yHfUEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_RupbAnfUEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
-          <children xsi:type="notation:BasicCompartment" xmi:id="_f0jIeUcxEe6bIJjw8ZnZGQ" type="StereotypeBrace">
-            <eAnnotations xmi:id="_w6t_MEcxEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-              <details xmi:id="_w6t_MUcxEe6bIJjw8ZnZGQ" key="visible" value="true"/>
+          <children xsi:type="notation:BasicCompartment" xmi:id="_9X7ZgHfTEe6iN6ao8wePZw" type="StereotypeBrace">
+            <eAnnotations xmi:id="_e7dakHfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+              <details xmi:id="_e7dakXfUEe6iN6ao8wePZw" key="visible" value="true"/>
             </eAnnotations>
-            <styles xsi:type="notation:TitleStyle" xmi:id="_f0jIekcxEe6bIJjw8ZnZGQ"/>
-            <styles xsi:type="notation:StringValueStyle" xmi:id="_f0jIe0cxEe6bIJjw8ZnZGQ" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
+            <styles xsi:type="notation:TitleStyle" xmi:id="_9X7ZgXfTEe6iN6ao8wePZw"/>
+            <styles xsi:type="notation:StringValueStyle" xmi:id="_9X7ZgnfTEe6iN6ao8wePZw" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
             <element href="UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_6vylQKZvEe2n-fmfRwdlPg"/>
-            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_f0jIfEcxEe6bIJjw8ZnZGQ"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_9X7Zg3fTEe6iN6ao8wePZw"/>
           </children>
           <element href="TapiGnmiStreaming.uml#__6_sHUcnEe6bIJjw8ZnZGQ"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="__k2rXUcsEe6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_9WRzs3fTEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="__k2rXkcsEe6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="__k2rX0csEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="__k2rYEcsEe6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="__k2rYUcsEe6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="__k2rYkcsEe6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_9WRztHfTEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_RulJmHfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_RulJmXfUEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_Runl0HfUEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_RupbA3fUEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
-          <children xsi:type="notation:BasicCompartment" xmi:id="_jb0xIEcxEe6bIJjw8ZnZGQ" type="StereotypeBrace">
-            <eAnnotations xmi:id="_wlRToEcxEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-              <details xmi:id="_wlRToUcxEe6bIJjw8ZnZGQ" key="visible" value="true"/>
+          <children xsi:type="notation:BasicCompartment" xmi:id="_9X_q8HfTEe6iN6ao8wePZw" type="StereotypeBrace">
+            <eAnnotations xmi:id="_fWES8HfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+              <details xmi:id="_fWES8XfUEe6iN6ao8wePZw" key="visible" value="true"/>
             </eAnnotations>
-            <styles xsi:type="notation:TitleStyle" xmi:id="_jb0xIUcxEe6bIJjw8ZnZGQ"/>
-            <styles xsi:type="notation:StringValueStyle" xmi:id="_jb0xIkcxEe6bIJjw8ZnZGQ" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
+            <styles xsi:type="notation:TitleStyle" xmi:id="_9X_q8XfTEe6iN6ao8wePZw"/>
+            <styles xsi:type="notation:StringValueStyle" xmi:id="_9X_q8nfTEe6iN6ao8wePZw" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
             <element href="UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_6vylQKZvEe2n-fmfRwdlPg"/>
-            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_jb0xI0cxEe6bIJjw8ZnZGQ"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_9X_q83fTEe6iN6ao8wePZw"/>
           </children>
           <element href="TapiGnmiStreaming.uml#__6_sH0cnEe6bIJjw8ZnZGQ"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="__k2rY0csEe6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_9WRztXfTEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="__k2rZEcsEe6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="__k2rZUcsEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="__k2rZkcsEe6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="__k2rZ0csEe6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="__k2raEcsEe6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_9WSawHfTEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_RulJmnfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_RulJm3fUEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_Runl0XfUEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_RupbBHfUEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
-          <children xsi:type="notation:BasicCompartment" xmi:id="_nBRN3EcxEe6bIJjw8ZnZGQ" type="StereotypeBrace">
-            <eAnnotations xmi:id="_waHMgEcxEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-              <details xmi:id="_waHMgUcxEe6bIJjw8ZnZGQ" key="visible" value="true"/>
+          <children xsi:type="notation:BasicCompartment" xmi:id="_9YFKgHfTEe6iN6ao8wePZw" type="StereotypeBrace">
+            <eAnnotations xmi:id="_fvKIYHfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+              <details xmi:id="_fvKIYXfUEe6iN6ao8wePZw" key="visible" value="true"/>
             </eAnnotations>
-            <styles xsi:type="notation:TitleStyle" xmi:id="_nBR04EcxEe6bIJjw8ZnZGQ"/>
-            <styles xsi:type="notation:StringValueStyle" xmi:id="_nBR04UcxEe6bIJjw8ZnZGQ" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
+            <styles xsi:type="notation:TitleStyle" xmi:id="_9YFKgXfTEe6iN6ao8wePZw"/>
+            <styles xsi:type="notation:StringValueStyle" xmi:id="_9YFKgnfTEe6iN6ao8wePZw" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
             <element href="UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_6vylQKZvEe2n-fmfRwdlPg"/>
-            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_nBR04kcxEe6bIJjw8ZnZGQ"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_9YFKg3fTEe6iN6ao8wePZw"/>
           </children>
           <element href="TapiGnmiStreaming.uml#__6_sIUcnEe6bIJjw8ZnZGQ"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="__k2raUcsEe6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_9WSawXfTEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="__k2rakcsEe6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="__k2ra0csEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="__k2rbEcsEe6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="__k2rbUcsEe6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="__k2rbkcsEe6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_9WTB0HfTEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_RulJnHfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_RulJnXfUEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_Runl0nfUEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_RupbBXfUEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
-          <children xsi:type="notation:BasicCompartment" xmi:id="_qe81rEcxEe6bIJjw8ZnZGQ" type="StereotypeBrace">
-            <eAnnotations xmi:id="_wPNkEEcxEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-              <details xmi:id="_wPNkEUcxEe6bIJjw8ZnZGQ" key="visible" value="true"/>
+          <children xsi:type="notation:BasicCompartment" xmi:id="_9YKDA3fTEe6iN6ao8wePZw" type="StereotypeBrace">
+            <eAnnotations xmi:id="_gHkBUHfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+              <details xmi:id="_gHkBUXfUEe6iN6ao8wePZw" key="visible" value="true"/>
             </eAnnotations>
-            <styles xsi:type="notation:TitleStyle" xmi:id="_qe81rUcxEe6bIJjw8ZnZGQ"/>
-            <styles xsi:type="notation:StringValueStyle" xmi:id="_qe81rkcxEe6bIJjw8ZnZGQ" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
+            <styles xsi:type="notation:TitleStyle" xmi:id="_9YKDBHfTEe6iN6ao8wePZw"/>
+            <styles xsi:type="notation:StringValueStyle" xmi:id="_9YKDBXfTEe6iN6ao8wePZw" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
             <element href="UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_6vylQKZvEe2n-fmfRwdlPg"/>
-            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_qe81r0cxEe6bIJjw8ZnZGQ"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_9YKDBnfTEe6iN6ao8wePZw"/>
           </children>
           <element href="TapiGnmiStreaming.uml#__6_sI0cnEe6bIJjw8ZnZGQ"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="__k2rb0csEe6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_9WTB0XfTEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="__k2rcEcsEe6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="__k2rcUcsEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="__k2rckcsEe6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="__k2rc0csEe6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="__k2rdEcsEe6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_9WTB0nfTEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_RulJnnfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_RulJn3fUEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_Runl03fUEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_RuqCEHfUEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
-          <children xsi:type="notation:BasicCompartment" xmi:id="_2amvXEcxEe6bIJjw8ZnZGQ" type="StereotypeBrace">
-            <eAnnotations xmi:id="_RIFekEcyEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-              <details xmi:id="_RIFekUcyEe6bIJjw8ZnZGQ" key="visible" value="true"/>
+          <children xsi:type="notation:BasicCompartment" xmi:id="_9YOUc3fTEe6iN6ao8wePZw" type="StereotypeBrace">
+            <eAnnotations xmi:id="_ggp2wHfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+              <details xmi:id="_ggp2wXfUEe6iN6ao8wePZw" key="visible" value="true"/>
             </eAnnotations>
-            <styles xsi:type="notation:TitleStyle" xmi:id="_2amvXUcxEe6bIJjw8ZnZGQ"/>
-            <styles xsi:type="notation:StringValueStyle" xmi:id="_2amvXkcxEe6bIJjw8ZnZGQ" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
+            <styles xsi:type="notation:TitleStyle" xmi:id="_9YOUdHfTEe6iN6ao8wePZw"/>
+            <styles xsi:type="notation:StringValueStyle" xmi:id="_9YOUdXfTEe6iN6ao8wePZw" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
             <element href="UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_6vylQKZvEe2n-fmfRwdlPg"/>
-            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_2amvX0cxEe6bIJjw8ZnZGQ"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_9YOUdnfTEe6iN6ao8wePZw"/>
           </children>
           <element href="TapiGnmiStreaming.uml#__6_sJEcnEe6bIJjw8ZnZGQ"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="__k2rdUcsEe6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_9WTB03fTEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="__k2rdkcsEe6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="__k2rd0csEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="__k2reEcsEe6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="__k2reUcsEe6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="__k2rekcsEe6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_9WTo4HfTEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_RulJoHfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_RulJoXfUEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_Runl1HfUEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_RuqCEXfUEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
-          <children xsi:type="notation:BasicCompartment" xmi:id="_6i7PnEcxEe6bIJjw8ZnZGQ" type="StereotypeBrace">
-            <eAnnotations xmi:id="_QL48EEcyEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-              <details xmi:id="_QL48EUcyEe6bIJjw8ZnZGQ" key="visible" value="true"/>
+          <children xsi:type="notation:BasicCompartment" xmi:id="_9YTM8HfTEe6iN6ao8wePZw" type="StereotypeBrace">
+            <eAnnotations xmi:id="_g5rawHfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+              <details xmi:id="_g5sB0HfUEe6iN6ao8wePZw" key="visible" value="true"/>
             </eAnnotations>
-            <styles xsi:type="notation:TitleStyle" xmi:id="_6i7PnUcxEe6bIJjw8ZnZGQ"/>
-            <styles xsi:type="notation:StringValueStyle" xmi:id="_6i7PnkcxEe6bIJjw8ZnZGQ" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
+            <styles xsi:type="notation:TitleStyle" xmi:id="_9YTM8XfTEe6iN6ao8wePZw"/>
+            <styles xsi:type="notation:StringValueStyle" xmi:id="_9YTM8nfTEe6iN6ao8wePZw" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
             <element href="UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_6vylQKZvEe2n-fmfRwdlPg"/>
-            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_6i7Pn0cxEe6bIJjw8ZnZGQ"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_9YTM83fTEe6iN6ao8wePZw"/>
           </children>
           <element href="TapiGnmiStreaming.uml#__6_sJUcnEe6bIJjw8ZnZGQ"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="__k2re0csEe6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_9WTo4XfTEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="__k2rfEcsEe6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="__k2rfUcsEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="__k2rfkcsEe6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="__k2rf0csEe6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="__k2rgEcsEe6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_9WTo4nfTEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_RulwoHfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_RulwoXfUEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_Runl1XfUEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_RuqCEnfUEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
-          <children xsi:type="notation:BasicCompartment" xmi:id="_94YIfEcxEe6bIJjw8ZnZGQ" type="StereotypeBrace">
-            <eAnnotations xmi:id="_Q0qzUEcyEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-              <details xmi:id="_Q0qzUUcyEe6bIJjw8ZnZGQ" key="visible" value="true"/>
+          <children xsi:type="notation:BasicCompartment" xmi:id="_9YWQQ3fTEe6iN6ao8wePZw" type="StereotypeBrace">
+            <eAnnotations xmi:id="_jApuUHfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+              <details xmi:id="_jAqVYHfUEe6iN6ao8wePZw" key="visible" value="true"/>
             </eAnnotations>
-            <styles xsi:type="notation:TitleStyle" xmi:id="_94YIfUcxEe6bIJjw8ZnZGQ"/>
-            <styles xsi:type="notation:StringValueStyle" xmi:id="_94YIfkcxEe6bIJjw8ZnZGQ" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
+            <styles xsi:type="notation:TitleStyle" xmi:id="_9YWQRHfTEe6iN6ao8wePZw"/>
+            <styles xsi:type="notation:StringValueStyle" xmi:id="_9YWQRXfTEe6iN6ao8wePZw" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
             <element href="UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_6vylQKZvEe2n-fmfRwdlPg"/>
-            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_94YIf0cxEe6bIJjw8ZnZGQ"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_9YWQRnfTEe6iN6ao8wePZw"/>
+          </children>
+          <element href="TapiGnmiStreaming.uml#_aTg74HfQEe6iN6ao8wePZw"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_9WTo43fTEe6iN6ao8wePZw"/>
+        </children>
+        <children xsi:type="notation:Shape" xmi:id="_9WUP8HfTEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_RulwonfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_Rulwo3fUEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_Runl1nfUEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_RuqCE3fUEe6iN6ao8wePZw" key="fontColor" value="true"/>
+          </eAnnotations>
+          <children xsi:type="notation:BasicCompartment" xmi:id="_9YZ6o3fTEe6iN6ao8wePZw" type="StereotypeBrace">
+            <eAnnotations xmi:id="_jZaMkHfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+              <details xmi:id="_jZazoHfUEe6iN6ao8wePZw" key="visible" value="true"/>
+            </eAnnotations>
+            <styles xsi:type="notation:TitleStyle" xmi:id="_9YZ6pHfTEe6iN6ao8wePZw"/>
+            <styles xsi:type="notation:StringValueStyle" xmi:id="_9YZ6pXfTEe6iN6ao8wePZw" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
+            <element href="UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_6vylQKZvEe2n-fmfRwdlPg"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_9YZ6pnfTEe6iN6ao8wePZw"/>
+          </children>
+          <element href="TapiGnmiStreaming.uml#_dmUwcHfQEe6iN6ao8wePZw"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_9WUP8XfTEe6iN6ao8wePZw"/>
+        </children>
+        <children xsi:type="notation:Shape" xmi:id="_9WUP8nfTEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_RulwpHfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_RulwpXfUEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_Runl13fUEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_RuqCFHfUEe6iN6ao8wePZw" key="fontColor" value="true"/>
+          </eAnnotations>
+          <children xsi:type="notation:BasicCompartment" xmi:id="_9YdlAHfTEe6iN6ao8wePZw" type="StereotypeBrace">
+            <eAnnotations xmi:id="_jzF34HfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+              <details xmi:id="_jzGe8HfUEe6iN6ao8wePZw" key="visible" value="true"/>
+            </eAnnotations>
+            <styles xsi:type="notation:TitleStyle" xmi:id="_9YdlAXfTEe6iN6ao8wePZw"/>
+            <styles xsi:type="notation:StringValueStyle" xmi:id="_9YdlAnfTEe6iN6ao8wePZw" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
+            <element href="UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_6vylQKZvEe2n-fmfRwdlPg"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_9YdlA3fTEe6iN6ao8wePZw"/>
           </children>
           <element href="TapiGnmiStreaming.uml#__6_sJkcnEe6bIJjw8ZnZGQ"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="__k2rgUcsEe6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_9WUP83fTEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="__k2rgkcsEe6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="__k2rg0csEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="__k2rhEcsEe6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="__k2rhUcsEe6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="__k2rhkcsEe6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_9WU3AHfTEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_RulwpnfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_Rulwp3fUEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_RuoM4HfUEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_RuqCFXfUEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
-          <children xsi:type="notation:BasicCompartment" xmi:id="_BRI0CUcyEe6bIJjw8ZnZGQ" type="StereotypeBrace">
-            <eAnnotations xmi:id="_RSv2cEcyEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-              <details xmi:id="_RSv2cUcyEe6bIJjw8ZnZGQ" key="visible" value="true"/>
+          <children xsi:type="notation:BasicCompartment" xmi:id="_9YgoU3fTEe6iN6ao8wePZw" type="StereotypeBrace">
+            <eAnnotations xmi:id="_kN-dEHfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+              <details xmi:id="_kN-dEXfUEe6iN6ao8wePZw" key="visible" value="true"/>
             </eAnnotations>
-            <styles xsi:type="notation:TitleStyle" xmi:id="_BRI0CkcyEe6bIJjw8ZnZGQ"/>
-            <styles xsi:type="notation:StringValueStyle" xmi:id="_BRI0C0cyEe6bIJjw8ZnZGQ" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
+            <styles xsi:type="notation:TitleStyle" xmi:id="_9YgoVHfTEe6iN6ao8wePZw"/>
+            <styles xsi:type="notation:StringValueStyle" xmi:id="_9YgoVXfTEe6iN6ao8wePZw" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
             <element href="UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_6vylQKZvEe2n-fmfRwdlPg"/>
-            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_BRI0DEcyEe6bIJjw8ZnZGQ"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_9YgoVnfTEe6iN6ao8wePZw"/>
           </children>
           <element href="TapiGnmiStreaming.uml#__6_sJ0cnEe6bIJjw8ZnZGQ"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="__k2rh0csEe6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_9WU3AXfTEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="__k2riEcsEe6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="__k2riUcsEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="__k2rikcsEe6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="__k2ri0csEe6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="__k2rjEcsEe6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_9WVeEHfTEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_RulwqHfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_RulwqXfUEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_RuoM4XfUEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_RuqCFnfUEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
-          <children xsi:type="notation:BasicCompartment" xmi:id="_EvGIrEcyEe6bIJjw8ZnZGQ" type="StereotypeBrace">
-            <eAnnotations xmi:id="_QiKHAEcyEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-              <details xmi:id="_QiKHAUcyEe6bIJjw8ZnZGQ" key="visible" value="true"/>
+          <children xsi:type="notation:BasicCompartment" xmi:id="_9Yjro3fTEe6iN6ao8wePZw" type="StereotypeBrace">
+            <eAnnotations xmi:id="_knB2QHfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+              <details xmi:id="_knB2QXfUEe6iN6ao8wePZw" key="visible" value="true"/>
             </eAnnotations>
-            <styles xsi:type="notation:TitleStyle" xmi:id="_EvGIrUcyEe6bIJjw8ZnZGQ"/>
-            <styles xsi:type="notation:StringValueStyle" xmi:id="_EvGIrkcyEe6bIJjw8ZnZGQ" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
+            <styles xsi:type="notation:TitleStyle" xmi:id="_9YjrpHfTEe6iN6ao8wePZw"/>
+            <styles xsi:type="notation:StringValueStyle" xmi:id="_9YjrpXfTEe6iN6ao8wePZw" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
             <element href="UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_6vylQKZvEe2n-fmfRwdlPg"/>
-            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_EvGIr0cyEe6bIJjw8ZnZGQ"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_9YjrpnfTEe6iN6ao8wePZw"/>
           </children>
           <element href="TapiGnmiStreaming.uml#__6_sKUcnEe6bIJjw8ZnZGQ"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="__k2rjUcsEe6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_9WVeEXfTEe6iN6ao8wePZw"/>
         </children>
-        <children xsi:type="notation:Shape" xmi:id="__k2rjkcsEe6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
-          <eAnnotations xmi:id="__k2rj0csEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-            <details xmi:id="__k2rkEcsEe6bIJjw8ZnZGQ" key="bold" value="true"/>
-            <details xmi:id="__k2rkUcsEe6bIJjw8ZnZGQ" key="italic" value="true"/>
-            <details xmi:id="__k2rkkcsEe6bIJjw8ZnZGQ" key="fontColor" value="true"/>
+        <children xsi:type="notation:Shape" xmi:id="_9WWFIHfTEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_RulwqnfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_Rulwq3fUEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_RuoM4nfUEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_RuqCF3fUEe6iN6ao8wePZw" key="fontColor" value="true"/>
           </eAnnotations>
-          <children xsi:type="notation:BasicCompartment" xmi:id="_IIOAnEcyEe6bIJjw8ZnZGQ" type="StereotypeBrace">
-            <eAnnotations xmi:id="_Usy7cEcyEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
-              <details xmi:id="_Usy7cUcyEe6bIJjw8ZnZGQ" key="visible" value="true"/>
+          <children xsi:type="notation:BasicCompartment" xmi:id="_9YpyQ3fTEe6iN6ao8wePZw" type="StereotypeBrace">
+            <eAnnotations xmi:id="_lffvUHfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+              <details xmi:id="_lffvUXfUEe6iN6ao8wePZw" key="visible" value="true"/>
             </eAnnotations>
-            <styles xsi:type="notation:TitleStyle" xmi:id="_IIOAnUcyEe6bIJjw8ZnZGQ"/>
-            <styles xsi:type="notation:StringValueStyle" xmi:id="_IIOAnkcyEe6bIJjw8ZnZGQ" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
+            <styles xsi:type="notation:TitleStyle" xmi:id="_9YpyRHfTEe6iN6ao8wePZw"/>
+            <styles xsi:type="notation:StringValueStyle" xmi:id="_9YpyRXfTEe6iN6ao8wePZw" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
             <element href="UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_6vylQKZvEe2n-fmfRwdlPg"/>
-            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_IIOAn0cyEe6bIJjw8ZnZGQ"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_9YpyRnfTEe6iN6ao8wePZw"/>
           </children>
           <element href="TapiGnmiStreaming.uml#__6_sKkcnEe6bIJjw8ZnZGQ"/>
-          <layoutConstraint xsi:type="notation:Location" xmi:id="__k2rk0csEe6bIJjw8ZnZGQ"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_9WWFIXfTEe6iN6ao8wePZw"/>
+        </children>
+        <children xsi:type="notation:Shape" xmi:id="_9WWsMHfTEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_RulwrHfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_RulwrXfUEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_RuoM43fUEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_RuqpIHfUEe6iN6ao8wePZw" key="fontColor" value="true"/>
+          </eAnnotations>
+          <children xsi:type="notation:BasicCompartment" xmi:id="_9YvR0HfTEe6iN6ao8wePZw" type="StereotypeBrace">
+            <eAnnotations xmi:id="_l4MjMHfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+              <details xmi:id="_l4MjMXfUEe6iN6ao8wePZw" key="visible" value="true"/>
+            </eAnnotations>
+            <styles xsi:type="notation:TitleStyle" xmi:id="_9YvR0XfTEe6iN6ao8wePZw"/>
+            <styles xsi:type="notation:StringValueStyle" xmi:id="_9YvR0nfTEe6iN6ao8wePZw" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
+            <element href="UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_6vylQKZvEe2n-fmfRwdlPg"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_9YvR03fTEe6iN6ao8wePZw"/>
+          </children>
+          <element href="TapiGnmiStreaming.uml#_knymIHciEe6iN6ao8wePZw"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_9WWsMXfTEe6iN6ao8wePZw"/>
+        </children>
+        <children xsi:type="notation:Shape" xmi:id="_9WXTQHfTEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_RumXsHfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_RumXsXfUEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_RuoM5HfUEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_RuqpIXfUEe6iN6ao8wePZw" key="fontColor" value="true"/>
+          </eAnnotations>
+          <children xsi:type="notation:BasicCompartment" xmi:id="_9Y0KU3fTEe6iN6ao8wePZw" type="StereotypeBrace">
+            <eAnnotations xmi:id="_mRi3UHfUEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+              <details xmi:id="_mRjeYHfUEe6iN6ao8wePZw" key="visible" value="true"/>
+            </eAnnotations>
+            <styles xsi:type="notation:TitleStyle" xmi:id="_9Y0KVHfTEe6iN6ao8wePZw"/>
+            <styles xsi:type="notation:StringValueStyle" xmi:id="_9Y0KVXfTEe6iN6ao8wePZw" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
+            <element href="UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_6vylQKZvEe2n-fmfRwdlPg"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_9Y0KVnfTEe6iN6ao8wePZw"/>
+          </children>
+          <element href="TapiGnmiStreaming.uml#_sSqnIHciEe6iN6ao8wePZw"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_9WXTQXfTEe6iN6ao8wePZw"/>
         </children>
         <styles xsi:type="notation:TitleStyle" xmi:id="__k2rlEcsEe6bIJjw8ZnZGQ"/>
         <styles xsi:type="notation:SortingStyle" xmi:id="__k2rlUcsEe6bIJjw8ZnZGQ"/>
@@ -10436,7 +10742,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="__k2rl0csEe6bIJjw8ZnZGQ"/>
       </children>
       <element href="TapiGnmiStreaming.uml#__6_sAEcnEe6bIJjw8ZnZGQ"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="__k2rm0csEe6bIJjw8ZnZGQ" x="1320" y="140" width="381" height="441"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="__k2rm0csEe6bIJjw8ZnZGQ" x="1320" y="140" width="381" height="561"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="__k3RsEcsEe6bIJjw8ZnZGQ" type="Enumeration_Shape" fontName="Segoe UI" fontHeight="6" fillColor="8905185">
       <eAnnotations xmi:id="__k3RsUcsEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
@@ -10585,7 +10891,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="__k3SM0csEe6bIJjw8ZnZGQ"/>
       </children>
       <element href="TapiGnmiStreaming.uml#_FbS6sKbpEe2n-fmfRwdlPg"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="__k3SN0csEe6bIJjw8ZnZGQ" x="520" y="420" width="421" height="161"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="__k3SN0csEe6bIJjw8ZnZGQ" x="520" y="420" width="421" height="181"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="__k34wEcsEe6bIJjw8ZnZGQ" type="Enumeration_Shape" fontName="Segoe UI" fontHeight="6" fillColor="8905185">
       <eAnnotations xmi:id="__k34wUcsEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
@@ -10601,6 +10907,24 @@
         <layoutConstraint xsi:type="notation:Location" xmi:id="__k34x0csEe6bIJjw8ZnZGQ" y="15"/>
       </children>
       <children xsi:type="notation:BasicCompartment" xmi:id="__k34yEcsEe6bIJjw8ZnZGQ" type="Enumeration_LiteralCompartment">
+        <children xsi:type="notation:Shape" xmi:id="_JpExIHfLEe6iN6ao8wePZw" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
+          <eAnnotations xmi:id="_OycesHfLEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+            <details xmi:id="_OycesXfLEe6iN6ao8wePZw" key="bold" value="true"/>
+            <details xmi:id="_OydFwHfLEe6iN6ao8wePZw" key="italic" value="true"/>
+            <details xmi:id="_Oyds0HfLEe6iN6ao8wePZw" key="fontColor" value="true"/>
+          </eAnnotations>
+          <children xsi:type="notation:BasicCompartment" xmi:id="_JqWjg3fLEe6iN6ao8wePZw" type="StereotypeBrace">
+            <eAnnotations xmi:id="_MdfZgHfLEe6iN6ao8wePZw" source="PapyrusCSSForceValue">
+              <details xmi:id="_MdfZgXfLEe6iN6ao8wePZw" key="visible" value="true"/>
+            </eAnnotations>
+            <styles xsi:type="notation:TitleStyle" xmi:id="_JqWjhHfLEe6iN6ao8wePZw"/>
+            <styles xsi:type="notation:StringValueStyle" xmi:id="_JqWjhXfLEe6iN6ao8wePZw" name="stereotype" stringValue="OpenInterfaceModel_Profile::OpenInterfaceEnumerationLiteral"/>
+            <element href="UmlProfiles/OpenInterfaceModelProfile/OpenInterfaceModel_Profile.profile.uml#_6vylQKZvEe2n-fmfRwdlPg"/>
+            <layoutConstraint xsi:type="notation:Bounds" xmi:id="_JqWjhnfLEe6iN6ao8wePZw"/>
+          </children>
+          <element href="TapiGnmiStreaming.uml#_Gux9wHccEe6iN6ao8wePZw"/>
+          <layoutConstraint xsi:type="notation:Location" xmi:id="_JpExIXfLEe6iN6ao8wePZw"/>
+        </children>
         <children xsi:type="notation:Shape" xmi:id="__k34yUcsEe6bIJjw8ZnZGQ" type="EnumerationLiteral_LiteralLabel" fontName="Segoe UI" fontHeight="6">
           <eAnnotations xmi:id="__k34ykcsEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
             <details xmi:id="__k34y0csEe6bIJjw8ZnZGQ" key="bold" value="true"/>
@@ -10680,7 +11004,7 @@
         <layoutConstraint xsi:type="notation:Bounds" xmi:id="__k35EEcsEe6bIJjw8ZnZGQ"/>
       </children>
       <element href="TapiGnmiStreaming.uml#_OSJcgKZuEe2n-fmfRwdlPg"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="__k35FEcsEe6bIJjw8ZnZGQ" x="320" y="260" width="261" height="121"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="__k35FEcsEe6bIJjw8ZnZGQ" x="320" y="260" width="261" height="141"/>
     </children>
     <children xsi:type="notation:Shape" xmi:id="__k35FUcsEe6bIJjw8ZnZGQ" type="Class_Shape" fontName="Segoe UI" fontHeight="6" fillColor="12621752">
       <eAnnotations xmi:id="__k35FkcsEe6bIJjw8ZnZGQ" source="PapyrusCSSForceValue">
@@ -11108,22 +11432,6 @@
       <element href="TapiCommon.uml#_6efrYNnVEeWIOYiRCk5bbQ"/>
       <layoutConstraint xsi:type="notation:Bounds" xmi:id="_EiusYVegEe6mE7NoRC7Zaw" x="1780" y="40" width="241" height="83"/>
     </children>
-    <children xsi:type="notation:Shape" xmi:id="_liFKAGnCEe6M0MEaxCUWiQ" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_liFKAWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_liFxEGnCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
-        <eObjectValue href="TapiGnmiStreaming.uml#_406Q8KFhEe2n-fmfRwdlPg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_liFKAmnCEe6M0MEaxCUWiQ" x="880" y="40"/>
-    </children>
-    <children xsi:type="notation:Shape" xmi:id="_li8FoGnCEe6M0MEaxCUWiQ" type="StereotypeComment">
-      <styles xsi:type="notation:TitleStyle" xmi:id="_li8FoWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_li8Fo2nCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
-        <eObjectValue href="TapiGnmiStreaming.uml#_KRgyMFIQEe6m_d6KGfEFwg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_li8FomnCEe6M0MEaxCUWiQ" x="880" y="160"/>
-    </children>
     <children xsi:type="notation:Shape" xmi:id="_0ByfYGnDEe6M0MEaxCUWiQ" type="Enumeration_Shape" fontName="Segoe UI" fontHeight="6" fillColor="10265827">
       <eAnnotations xmi:id="_xC_WgGnEEe6M0MEaxCUWiQ" source="PapyrusCSSForceValue">
         <details xmi:id="_xC_9kGnEEe6M0MEaxCUWiQ" key="bold" value="true"/>
@@ -11198,6 +11506,22 @@
       <element href="TapiGnmiStreaming.uml#_1so3oGnDEe6M0MEaxCUWiQ"/>
       <layoutConstraint xsi:type="notation:Bounds" xmi:id="_1s9AsWnDEe6M0MEaxCUWiQ" x="680" y="620"/>
     </children>
+    <children xsi:type="notation:Shape" xmi:id="_0SOvYHfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_0SOvYXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_0SOvY3fKEe6iN6ao8wePZw" name="BASE_ELEMENT">
+        <eObjectValue href="TapiGnmiStreaming.uml#_406Q8KFhEe2n-fmfRwdlPg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_0SOvYnfKEe6iN6ao8wePZw" x="880" y="40"/>
+    </children>
+    <children xsi:type="notation:Shape" xmi:id="_0SwT0HfKEe6iN6ao8wePZw" type="StereotypeComment">
+      <styles xsi:type="notation:TitleStyle" xmi:id="_0Sw64HfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_0Sw64nfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
+        <eObjectValue href="TapiGnmiStreaming.uml#_KRgyMFIQEe6m_d6KGfEFwg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <layoutConstraint xsi:type="notation:Bounds" xmi:id="_0Sw64XfKEe6iN6ao8wePZw" x="880" y="160"/>
+    </children>
     <styles xsi:type="notation:StringValueStyle" xmi:id="_c-ZM8UcsEe6bIJjw8ZnZGQ" name="diagram_compatibility_version" stringValue="1.4.0"/>
     <styles xsi:type="notation:DiagramStyle" xmi:id="_c-ZM8kcsEe6bIJjw8ZnZGQ"/>
     <styles xsi:type="style:PapyrusDiagramStyle" xmi:id="_c-ZM80csEe6bIJjw8ZnZGQ" diagramKindId="org.eclipse.papyrus.uml.diagram.class">
@@ -11247,7 +11571,7 @@
       <element href="TapiGnmiStreaming.uml#_rvpI0EcuEe6bIJjw8ZnZGQ"/>
       <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_rvpv4kcuEe6bIJjw8ZnZGQ" points="[780, 361, -643984, -643984]$[680, 240, -643984, -643984]"/>
       <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_rxp7AEcuEe6bIJjw8ZnZGQ" id="(0.0,0.7960199004975125)"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_rxp7AUcuEe6bIJjw8ZnZGQ" id="(1.0,0.49586776859504134)"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_rxp7AUcuEe6bIJjw8ZnZGQ" id="(1.0,0.425531914893617)"/>
     </edges>
     <edges xsi:type="notation:Connector" xmi:id="_toe5wEcuEe6bIJjw8ZnZGQ" type="Usage_Edge" source="_jjNGoFIVEe6m_d6KGfEFwg" target="__k3RsEcsEe6bIJjw8ZnZGQ">
       <children xsi:type="notation:DecorationNode" xmi:id="_toe5w0cuEe6bIJjw8ZnZGQ" type="Usage_NameLabel">
@@ -11262,7 +11586,7 @@
       <element href="TapiGnmiStreaming.uml#_toeSsEcuEe6bIJjw8ZnZGQ"/>
       <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_toe5wkcuEe6bIJjw8ZnZGQ" points="[880, 361, -643984, -643984]$[600, 480, -643984, -643984]"/>
       <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_tqVT4EcuEe6bIJjw8ZnZGQ" id="(0.10498687664041995,1.0)"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_tqV68EcuEe6bIJjw8ZnZGQ" id="(0.53156146179402,0.0)"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_tqV68EcuEe6bIJjw8ZnZGQ" id="(0.5225653206650831,0.0)"/>
     </edges>
     <edges xsi:type="notation:Connector" xmi:id="_vH5eEEcuEe6bIJjw8ZnZGQ" type="Usage_Edge" source="_jjNGoFIVEe6m_d6KGfEFwg" target="__k2q9UcsEe6bIJjw8ZnZGQ">
       <children xsi:type="notation:DecorationNode" xmi:id="_vH5eE0cuEe6bIJjw8ZnZGQ" type="Usage_NameLabel">
@@ -11277,7 +11601,7 @@
       <element href="TapiGnmiStreaming.uml#_vH43AEcuEe6bIJjw8ZnZGQ"/>
       <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_vH5eEkcuEe6bIJjw8ZnZGQ" points="[1141, 300, -643984, -643984]$[1160, 300, -643984, -643984]"/>
       <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_vJuqEEcuEe6bIJjw8ZnZGQ" id="(1.0,0.6965174129353234)"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_vJvRIEcuEe6bIJjw8ZnZGQ" id="(0.0,0.36281179138321995)"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_vJvRIEcuEe6bIJjw8ZnZGQ" id="(0.0,0.28520499108734404)"/>
     </edges>
     <edges xsi:type="notation:Connector" xmi:id="_wtx2wEcuEe6bIJjw8ZnZGQ" type="Usage_Edge" source="__k2q9UcsEe6bIJjw8ZnZGQ" target="__k2DkEcsEe6bIJjw8ZnZGQ">
       <children xsi:type="notation:DecorationNode" xmi:id="_wtx2w0cuEe6bIJjw8ZnZGQ" type="Usage_NameLabel">
@@ -11291,8 +11615,8 @@
       <styles xsi:type="notation:FontStyle" xmi:id="_wtx2wUcuEe6bIJjw8ZnZGQ"/>
       <element href="TapiGnmiStreaming.uml#_wtxPsEcuEe6bIJjw8ZnZGQ"/>
       <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_wtx2wkcuEe6bIJjw8ZnZGQ" points="[1421, 360, -643984, -643984]$[1440, 360, -643984, -643984]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_wvnCwEcuEe6bIJjw8ZnZGQ" id="(1.0,0.36281179138321995)"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_wvnCwUcuEe6bIJjw8ZnZGQ" id="(0.0,0.36281179138321995)"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_wvnCwEcuEe6bIJjw8ZnZGQ" id="(1.0,0.28520499108734404)"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_wvnCwUcuEe6bIJjw8ZnZGQ" id="(0.0,0.28520499108734404)"/>
     </edges>
     <edges xsi:type="notation:Connector" xmi:id="_zdx5MEcuEe6bIJjw8ZnZGQ" type="Usage_Edge" source="_jjNGoFIVEe6m_d6KGfEFwg" target="__k2qoEcsEe6bIJjw8ZnZGQ">
       <children xsi:type="notation:DecorationNode" xmi:id="_zdx5M0cuEe6bIJjw8ZnZGQ" type="Usage_NameLabel">
@@ -11339,26 +11663,6 @@
       <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_YUql0FegEe6mE7NoRC7Zaw" id="(1.0,0.39603960396039606)"/>
       <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_YUql0VegEe6mE7NoRC7Zaw" id="(0.0,0.4819277108433735)"/>
     </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_liFxEWnCEe6M0MEaxCUWiQ" type="StereotypeCommentLink" source="__k35FUcsEe6bIJjw8ZnZGQ" target="_liFKAGnCEe6M0MEaxCUWiQ">
-      <styles xsi:type="notation:FontStyle" xmi:id="_liFxEmnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_liFxFmnCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
-        <eObjectValue href="TapiGnmiStreaming.uml#_406Q8KFhEe2n-fmfRwdlPg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_liFxE2nCEe6M0MEaxCUWiQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_liFxFGnCEe6M0MEaxCUWiQ"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_liFxFWnCEe6M0MEaxCUWiQ"/>
-    </edges>
-    <edges xsi:type="notation:Connector" xmi:id="_li8ssGnCEe6M0MEaxCUWiQ" type="StereotypeCommentLink" source="_jjNGoFIVEe6m_d6KGfEFwg" target="_li8FoGnCEe6M0MEaxCUWiQ">
-      <styles xsi:type="notation:FontStyle" xmi:id="_li8ssWnCEe6M0MEaxCUWiQ"/>
-      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_li8stWnCEe6M0MEaxCUWiQ" name="BASE_ELEMENT">
-        <eObjectValue href="TapiGnmiStreaming.uml#_KRgyMFIQEe6m_d6KGfEFwg"/>
-      </styles>
-      <element xsi:nil="true"/>
-      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_li8ssmnCEe6M0MEaxCUWiQ" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
-      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_li8ss2nCEe6M0MEaxCUWiQ"/>
-      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_li8stGnCEe6M0MEaxCUWiQ"/>
-    </edges>
     <edges xsi:type="notation:Connector" xmi:id="_KBoa0GnEEe6M0MEaxCUWiQ" type="Abstraction_Edge" source="_1s9AsGnDEe6M0MEaxCUWiQ" target="_0ByfYGnDEe6M0MEaxCUWiQ" routing="Rectilinear">
       <eAnnotations xmi:id="_1TSuEGnEEe6M0MEaxCUWiQ" source="PapyrusCSSForceValue">
         <details xmi:id="_1TSuEWnEEe6M0MEaxCUWiQ" key="bold" value="true"/>
@@ -11378,6 +11682,26 @@
       <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_KBoa0mnEEe6M0MEaxCUWiQ" points="[680, 660, -643984, -643984]$[519, 660, -643984, -643984]$[519, 640, -643984, -643984]$[355, 640, -643984, -643984]"/>
       <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_KMGlcGnEEe6M0MEaxCUWiQ" id="(0.0,0.4)"/>
       <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_KMGlcWnEEe6M0MEaxCUWiQ" id="(1.0,0.4)"/>
+    </edges>
+    <edges xsi:type="notation:Connector" xmi:id="_0SPWcHfKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="__k35FUcsEe6bIJjw8ZnZGQ" target="_0SOvYHfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_0SPWcXfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_0SPWdXfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
+        <eObjectValue href="TapiGnmiStreaming.uml#_406Q8KFhEe2n-fmfRwdlPg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_0SPWcnfKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_0SPWc3fKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_0SPWdHfKEe6iN6ao8wePZw"/>
+    </edges>
+    <edges xsi:type="notation:Connector" xmi:id="_0Sw643fKEe6iN6ao8wePZw" type="StereotypeCommentLink" source="_jjNGoFIVEe6m_d6KGfEFwg" target="_0SwT0HfKEe6iN6ao8wePZw">
+      <styles xsi:type="notation:FontStyle" xmi:id="_0Sw65HfKEe6iN6ao8wePZw"/>
+      <styles xsi:type="notation:EObjectValueStyle" xmi:id="_0Sw66HfKEe6iN6ao8wePZw" name="BASE_ELEMENT">
+        <eObjectValue href="TapiGnmiStreaming.uml#_KRgyMFIQEe6m_d6KGfEFwg"/>
+      </styles>
+      <element xsi:nil="true"/>
+      <bendpoints xsi:type="notation:RelativeBendpoints" xmi:id="_0Sw65XfKEe6iN6ao8wePZw" points="[0, 0, 0, 0]$[0, 0, 0, 0]"/>
+      <sourceAnchor xsi:type="notation:IdentityAnchor" xmi:id="_0Sw65nfKEe6iN6ao8wePZw"/>
+      <targetAnchor xsi:type="notation:IdentityAnchor" xmi:id="_0Sw653fKEe6iN6ao8wePZw"/>
     </edges>
   </notation:Diagram>
 </xmi:XMI>

--- a/UML/TapiGnmiStreaming.uml
+++ b/UML/TapiGnmiStreaming.uml
@@ -44,6 +44,15 @@ License: This module is distributed under the Apache License 2.0</body>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_dQgAMD0uEeqNzoiCK4mkvg" name="TypeDefinitions">
       <packagedElement xmi:type="uml:Enumeration" xmi:id="_nwJQkKYQEe2n-fmfRwdlPg" name="ValueQualifier" isLeaf="true">
+        <ownedComment xmi:type="uml:Comment" xmi:id="_zoXeUEA4Ee6tO8bOoJ4-CQ" annotatedElement="_OSJcgKZuEe2n-fmfRwdlPg">
+          <body>The value qualifiers.</body>
+        </ownedComment>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_lH_CwHcaEe6iN6ao8wePZw" name="OK">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_yZD3QHcaEe6iN6ao8wePZw" annotatedElement="_lH_CwHcaEe6iN6ao8wePZw">
+            <body>There is no known problem with the value.&#xD;
+This is the default and need not be stated.</body>
+          </ownedComment>
+        </ownedLiteral>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_3_748KYQEe2n-fmfRwdlPg" name="INVALID">
           <ownedComment xmi:type="uml:Comment" xmi:id="_vOHygEA2Ee6tO8bOoJ4-CQ" annotatedElement="_3_748KYQEe2n-fmfRwdlPg">
             <body>This indicates that although there was a value provided by the measured system, it was clearly invalid. &#xD;
@@ -77,9 +86,12 @@ The value must be stated.</body>
         <ownedComment xmi:type="uml:Comment" xmi:id="_xXJCkEA4Ee6tO8bOoJ4-CQ" annotatedElement="_OSJcgKZuEe2n-fmfRwdlPg">
           <body>The sample qualifiers.</body>
         </ownedComment>
-        <ownedComment xmi:type="uml:Comment" xmi:id="_zoXeUEA4Ee6tO8bOoJ4-CQ" annotatedElement="_OSJcgKZuEe2n-fmfRwdlPg">
-          <body>The value qualifiers.</body>
-        </ownedComment>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_Gux9wHccEe6iN6ao8wePZw" name="NORMAL">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_QAc9cHccEe6iN6ao8wePZw" annotatedElement="_Gux9wHccEe6iN6ao8wePZw">
+            <body>A normal sample.&#xD;
+This is the default and need not be stated.</body>
+          </ownedComment>
+        </ownedLiteral>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_eNQY4KZvEe2n-fmfRwdlPg" name="DELAYED">
           <ownedComment xmi:type="uml:Comment" xmi:id="_Fnz74EA4Ee6tO8bOoJ4-CQ" annotatedElement="_eNQY4KZvEe2n-fmfRwdlPg">
             <body>The report about the sample is (significantly) delayed.&#xD;
@@ -118,7 +130,9 @@ The baseline samples must be qualified.</body>
         </ownedComment>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="__0PvcKbkEe2n-fmfRwdlPg" name="NEAR_END">
           <ownedComment xmi:type="uml:Comment" xmi:id="_eLvb4EDAEe6tO8bOoJ4-CQ" annotatedElement="__0PvcKbkEe2n-fmfRwdlPg">
-            <body>The measurement is about the point against which it is reported.</body>
+            <body>The measurement is about the point against which it is reported.&#xD;
+This applies to most measurements.&#xD;
+This is the default and need not be stated.</body>
           </ownedComment>
         </ownedLiteral>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_EKglEKblEe2n-fmfRwdlPg" name="FAR_END">
@@ -147,7 +161,9 @@ Where NEAR_END is the default, it is acceptable to not set NOT_APPLICABLE.</body
         </ownedComment>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_KQCcEKbpEe2n-fmfRwdlPg" name="NO_DIRECTION">
           <ownedComment xmi:type="uml:Comment" xmi:id="_Hj3WcEDIEe6tO8bOoJ4-CQ" annotatedElement="_KQCcEKbpEe2n-fmfRwdlPg">
-            <body>Where the measurement has no directionality, e.g., Temperature.</body>
+            <body>Where the measurement has no directionality, e.g., Temperature. &#xD;
+Where the measurement direction is obvious from the measurement type NO_DIRECTION may used.&#xD;
+This is the default and need not be stated.</body>
           </ownedComment>
         </ownedLiteral>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_0DnnwKbpEe2n-fmfRwdlPg" name="RECEIVE">
@@ -217,6 +233,7 @@ When this property is not present, the value can be assumed to be valid.&#xD;
 CONDITION: Mandatory as identified in the description above.</body>
           </ownedComment>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_U5O08KYQEe2n-fmfRwdlPg"/>
+          <defaultValue xmi:type="uml:InstanceValue" xmi:id="_dDDGgHcbEe6iN6ao8wePZw" instance="_lH_CwHcaEe6iN6ao8wePZw"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_VFFLMKxIEe2n-fmfRwdlPg" name="units" isReadOnly="true">
           <ownedComment xmi:type="uml:Comment" xmi:id="_OYm5MLwMEe2tPvK7TLwO7Q" annotatedElement="_VFFLMKxIEe2n-fmfRwdlPg">
@@ -295,13 +312,19 @@ Hence the YANG should convert into a protobuf map.</body>
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Enumeration" xmi:id="__6_sAEcnEe6bIJjw8ZnZGQ" name="NormalizedMeasurementType" isLeaf="true">
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_RpcNIHcfEe6iN6ao8wePZw" name="NO_NORMALIZED_TYPE">
+          <ownedComment xmi:type="uml:Comment" xmi:id="_EIZNgHcgEe6iN6ao8wePZw" annotatedElement="_RpcNIHcfEe6iN6ao8wePZw">
+            <body>The measurement does not have a defined normalized type.&#xD;
+This is the default and need not be stated.</body>
+          </ownedComment>
+        </ownedLiteral>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="__6_sAUcnEe6bIJjw8ZnZGQ" name="BBE"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="__6_sAkcnEe6bIJjw8ZnZGQ" name="CHROM_DISP">
           <ownedComment xmi:type="uml:Comment" xmi:id="__6_sA0cnEe6bIJjw8ZnZGQ" annotatedElement="__6_sAkcnEe6bIJjw8ZnZGQ">
             <body>Chromatic Dispersion</body>
           </ownedComment>
         </ownedLiteral>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="__6_sBEcnEe6bIJjw8ZnZGQ" name="DELAY"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="__6_sBEcnEe6bIJjw8ZnZGQ" name="DELAY_FRAME_COUNT"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="__6_sBUcnEe6bIJjw8ZnZGQ" name="DIFF_GROUP_DELAY">
           <ownedComment xmi:type="uml:Comment" xmi:id="__6_sBkcnEe6bIJjw8ZnZGQ" annotatedElement="__6_sBUcnEe6bIJjw8ZnZGQ">
             <body>Differential Group Delay</body>
@@ -403,8 +426,10 @@ references:&#xD;
           </ownedComment>
         </ownedLiteral>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="__6_sI0cnEe6bIJjw8ZnZGQ" name="OPTICAL_GAIN"/>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="__6_sJEcnEe6bIJjw8ZnZGQ" name="OPTICAL_POWER_INPUT"/>
-        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="__6_sJUcnEe6bIJjw8ZnZGQ" name="OPTICAL_POWER_OUTPUT"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="__6_sJEcnEe6bIJjw8ZnZGQ" name="OPT_PWR_SPECTR_DENS_INPUT"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="__6_sJUcnEe6bIJjw8ZnZGQ" name="OPT_PWR_SPECTR_DENS_OUTPUT"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_aTg74HfQEe6iN6ao8wePZw" name="OPT_TOTAL_PWR_INPUT"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_dmUwcHfQEe6iN6ao8wePZw" name="OPT_TOTAL_PWR_OUTPUT"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="__6_sJkcnEe6bIJjw8ZnZGQ" name="OPTICAL_TILT"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="__6_sJ0cnEe6bIJjw8ZnZGQ" name="POL_MODE_DISP">
           <ownedComment xmi:type="uml:Comment" xmi:id="__6_sKEcnEe6bIJjw8ZnZGQ" annotatedElement="__6_sJ0cnEe6bIJjw8ZnZGQ">
@@ -413,6 +438,8 @@ references:&#xD;
         </ownedLiteral>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="__6_sKUcnEe6bIJjw8ZnZGQ" name="SES"/>
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="__6_sKkcnEe6bIJjw8ZnZGQ" name="UAS"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_knymIHciEe6iN6ao8wePZw" name="VOA_INPUT"/>
+        <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_sSqnIHciEe6iN6ao8wePZw" name="VOA_OUTPUT"/>
       </packagedElement>
       <packagedElement xmi:type="uml:Enumeration" xmi:id="_1so3oGnDEe6M0MEaxCUWiQ" name="GnmiStreamingObjectType">
         <ownedLiteral xmi:type="uml:EnumerationLiteral" xmi:id="_a-s_8GnEEe6M0MEaxCUWiQ" name="MEASUREMENT_DETAILS"/>
@@ -592,14 +619,6 @@ CONDITION: Mandatory where stream is being used for measurment data.</body>
           <upperValue xmi:type="uml:LiteralUnlimitedNatural" xmi:id="_eRG1Iei9Ee2WXqIYPh2wfQ" value="1"/>
         </ownedAttribute>
       </packagedElement>
-      <packagedElement xmi:type="uml:Usage" xmi:id="_lK5CYEcuEe6bIJjw8ZnZGQ" client="_406Q8KFhEe2n-fmfRwdlPg" supplier="_tGy2YKJFEe2n-fmfRwdlPg"/>
-      <packagedElement xmi:type="uml:Usage" xmi:id="_rvpI0EcuEe6bIJjw8ZnZGQ" client="_kXVKYrv4Ee2tPvK7TLwO7Q _KRgyMFIQEe6m_d6KGfEFwg" supplier="_OSJcgKZuEe2n-fmfRwdlPg"/>
-      <packagedElement xmi:type="uml:Usage" xmi:id="_toeSsEcuEe6bIJjw8ZnZGQ" client="_FyZEkLv8Ee2tPvK7TLwO7Q _KRgyMFIQEe6m_d6KGfEFwg" supplier="_FbS6sKbpEe2n-fmfRwdlPg"/>
-      <packagedElement xmi:type="uml:Usage" xmi:id="_vH43AEcuEe6bIJjw8ZnZGQ" client="_KRgyMFIQEe6m_d6KGfEFwg" supplier="__6_sAEcnEe6bIJjw8ZnZGQ"/>
-      <packagedElement xmi:type="uml:Usage" xmi:id="_zdxSIEcuEe6bIJjw8ZnZGQ" client="_KRgyMFIQEe6m_d6KGfEFwg" supplier="_7yFhkKbkEe2n-fmfRwdlPg"/>
-      <packagedElement xmi:type="uml:Usage" xmi:id="_YDIw8FegEe6mE7NoRC7Zaw" client="_406Q8KFhEe2n-fmfRwdlPg">
-        <supplier xmi:type="uml:DataType" href="TapiCommon.uml#_6efrYNnVEeWIOYiRCk5bbQ"/>
-      </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_KRgyMFIQEe6m_d6KGfEFwg" name="QualifiedMeasurementCommon1To10">
         <ownedComment xmi:type="uml:Comment" xmi:id="_3xItoFIXEe6m_d6KGfEFwg" annotatedElement="_KRgyMFIQEe6m_d6KGfEFwg">
           <body>Provides the details of the measurement(s) being streamed from protobufEnumeration 1 to 10.</body>
@@ -640,6 +659,7 @@ CONDITION: Mandatory under most circumstances (should be provided unless not ava
 CONDITION: Mandatory where the measurement is not a &quot;normal&quot; measurement. </body>
           </ownedComment>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_mUResKIOEe2n-fmfRwdlPg"/>
+          <defaultValue xmi:type="uml:InstanceValue" xmi:id="_1jC1EHccEe6iN6ao8wePZw" instance="_Gux9wHccEe6iN6ao8wePZw"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_IhJq4KFjEe2n-fmfRwdlPg" name="relativePositionOfMeasurement" type="_7yFhkKbkEe2n-fmfRwdlPg" isReadOnly="true">
           <ownedComment xmi:type="uml:Comment" xmi:id="_-SgREP7iEe2-UqktnChz-w" annotatedElement="_IhJq4KFjEe2n-fmfRwdlPg">
@@ -658,6 +678,7 @@ The property intentionally has no default as the absence of the property means i
 CONDITION: Mandatory as identified in the description above.</body>
           </ownedComment>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_gsn5sKIOEe2n-fmfRwdlPg"/>
+          <defaultValue xmi:type="uml:InstanceValue" xmi:id="_iYLtQHcdEe6iN6ao8wePZw" instance="_KQCcEKbpEe2n-fmfRwdlPg"/>
         </ownedAttribute>
         <ownedAttribute xmi:type="uml:Property" xmi:id="_flV7EKFqEe2n-fmfRwdlPg" name="sampleInterval" isReadOnly="true">
           <ownedComment xmi:type="uml:Comment" xmi:id="_lTSGMLwBEe2tPvK7TLwO7Q" annotatedElement="_flV7EKFqEe2n-fmfRwdlPg">
@@ -742,6 +763,7 @@ This is a conditional property. &#xD;
 CONDITION: Mandatory where a normalized measurement type is available.</body>
           </ownedComment>
           <lowerValue xmi:type="uml:LiteralInteger" xmi:id="_est3cKIOEe2n-fmfRwdlPg"/>
+          <defaultValue xmi:type="uml:InstanceValue" xmi:id="_7FoXEHcgEe6iN6ao8wePZw" instance="_RpcNIHcfEe6iN6ao8wePZw"/>
         </ownedAttribute>
       </packagedElement>
       <packagedElement xmi:type="uml:Class" xmi:id="_FCwpUKYBEe2n-fmfRwdlPg" name="QualifiedMeasurement">
@@ -964,6 +986,14 @@ Hence the YANG should convert into a protobuf map.</body>
         </ownedComment>
         <supplier xmi:type="uml:Enumeration" href="TapiCommon.uml#_FFtS8CzeEeaYO8M_h7XJ5A"/>
       </packagedElement>
+      <packagedElement xmi:type="uml:Usage" xmi:id="_lK5CYEcuEe6bIJjw8ZnZGQ" client="_406Q8KFhEe2n-fmfRwdlPg" supplier="_tGy2YKJFEe2n-fmfRwdlPg"/>
+      <packagedElement xmi:type="uml:Usage" xmi:id="_rvpI0EcuEe6bIJjw8ZnZGQ" client="_kXVKYrv4Ee2tPvK7TLwO7Q _KRgyMFIQEe6m_d6KGfEFwg" supplier="_OSJcgKZuEe2n-fmfRwdlPg"/>
+      <packagedElement xmi:type="uml:Usage" xmi:id="_toeSsEcuEe6bIJjw8ZnZGQ" client="_FyZEkLv8Ee2tPvK7TLwO7Q _KRgyMFIQEe6m_d6KGfEFwg" supplier="_FbS6sKbpEe2n-fmfRwdlPg"/>
+      <packagedElement xmi:type="uml:Usage" xmi:id="_vH43AEcuEe6bIJjw8ZnZGQ" client="_KRgyMFIQEe6m_d6KGfEFwg" supplier="__6_sAEcnEe6bIJjw8ZnZGQ"/>
+      <packagedElement xmi:type="uml:Usage" xmi:id="_zdxSIEcuEe6bIJjw8ZnZGQ" client="_KRgyMFIQEe6m_d6KGfEFwg" supplier="_7yFhkKbkEe2n-fmfRwdlPg"/>
+      <packagedElement xmi:type="uml:Usage" xmi:id="_YDIw8FegEe6mE7NoRC7Zaw" client="_406Q8KFhEe2n-fmfRwdlPg">
+        <supplier xmi:type="uml:DataType" href="TapiCommon.uml#_6efrYNnVEeWIOYiRCk5bbQ"/>
+      </packagedElement>
     </packagedElement>
     <packagedElement xmi:type="uml:Package" xmi:id="_ETBuoD0xEeqNzoiCK4mkvg" name="Interfaces"/>
     <packagedElement xmi:type="uml:Package" xmi:id="_oVemwD3BEeqNzoiCK4mkvg" name="Imports">
@@ -1050,14 +1080,14 @@ Hence the YANG should convert into a protobuf map.</body>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_OJyW4KYPEe2n-fmfRwdlPg" base_Property="_OJvTkKYPEe2n-fmfRwdlPg" writeAllowed="WRITE_NOT_ALLOWED" protobufEnumeration="1"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_uBpgUaYPEe2n-fmfRwdlPg" base_StructuralFeature="_uBpgUKYPEe2n-fmfRwdlPg" isInvariant="true"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_uBtKsKYPEe2n-fmfRwdlPg" base_Property="_uBpgUKYPEe2n-fmfRwdlPg" writeAllowed="WRITE_NOT_ALLOWED" protobufEnumeration="2"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_WZFcgKZwEe2n-fmfRwdlPg" protobufEnumeration="0" base_EnumerationLiteral="_3_748KYQEe2n-fmfRwdlPg"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_aKq3wKZwEe2n-fmfRwdlPg" protobufEnumeration="1" base_EnumerationLiteral="_ELmkkKYREe2n-fmfRwdlPg"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_fzceIKZwEe2n-fmfRwdlPg" protobufEnumeration="2" base_EnumerationLiteral="_JviuQKYREe2n-fmfRwdlPg"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_k38SwKZwEe2n-fmfRwdlPg" protobufEnumeration="3" base_EnumerationLiteral="_m-fOgKYuEe2n-fmfRwdlPg"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_QFGggKZxEe2n-fmfRwdlPg" protobufEnumeration="0" base_EnumerationLiteral="_eNQY4KZvEe2n-fmfRwdlPg"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_eJxVIKZxEe2n-fmfRwdlPg" protobufEnumeration="1" base_EnumerationLiteral="_ikNyEKZvEe2n-fmfRwdlPg"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_jBmmwKZxEe2n-fmfRwdlPg" protobufEnumeration="2" base_EnumerationLiteral="_mkQgEKZvEe2n-fmfRwdlPg"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_oOaC0KZxEe2n-fmfRwdlPg" protobufEnumeration="3" base_EnumerationLiteral="_qRME0KZvEe2n-fmfRwdlPg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_WZFcgKZwEe2n-fmfRwdlPg" protobufEnumeration="1" base_EnumerationLiteral="_3_748KYQEe2n-fmfRwdlPg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_aKq3wKZwEe2n-fmfRwdlPg" protobufEnumeration="2" base_EnumerationLiteral="_ELmkkKYREe2n-fmfRwdlPg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_fzceIKZwEe2n-fmfRwdlPg" protobufEnumeration="3" base_EnumerationLiteral="_JviuQKYREe2n-fmfRwdlPg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_k38SwKZwEe2n-fmfRwdlPg" protobufEnumeration="4" base_EnumerationLiteral="_m-fOgKYuEe2n-fmfRwdlPg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_QFGggKZxEe2n-fmfRwdlPg" protobufEnumeration="1" base_EnumerationLiteral="_eNQY4KZvEe2n-fmfRwdlPg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_eJxVIKZxEe2n-fmfRwdlPg" protobufEnumeration="2" base_EnumerationLiteral="_ikNyEKZvEe2n-fmfRwdlPg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_jBmmwKZxEe2n-fmfRwdlPg" protobufEnumeration="3" base_EnumerationLiteral="_mkQgEKZvEe2n-fmfRwdlPg"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_oOaC0KZxEe2n-fmfRwdlPg" protobufEnumeration="4" base_EnumerationLiteral="_qRME0KZvEe2n-fmfRwdlPg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_uFgAUKblEe2n-fmfRwdlPg" protobufEnumeration="0" base_EnumerationLiteral="__0PvcKbkEe2n-fmfRwdlPg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_5LSpAKblEe2n-fmfRwdlPg" protobufEnumeration="1" base_EnumerationLiteral="_EKglEKblEe2n-fmfRwdlPg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_D0cmwKbrEe2n-fmfRwdlPg" protobufEnumeration="0" base_EnumerationLiteral="_KQCcEKbpEe2n-fmfRwdlPg"/>
@@ -1173,31 +1203,31 @@ Hence the YANG should convert into a protobuf map.</body>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_zx-12UOEEe6bIJjw8ZnZGQ" base_StructuralFeature="_zx-12EOEEe6bIJjw8ZnZGQ"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_zx-12kOEEe6bIJjw8ZnZGQ" base_Property="_zx-12EOEEe6bIJjw8ZnZGQ"/>
   <OpenModel_Profile:ExtendedComposite xmi:id="_3mzyUEOEEe6bIJjw8ZnZGQ" base_Association="_zx-10EOEEe6bIJjw8ZnZGQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_QLqZ8EcvEe6bIJjw8ZnZGQ" protobufEnumeration="0" base_EnumerationLiteral="__6_sAUcnEe6bIJjw8ZnZGQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_UBhRMEcvEe6bIJjw8ZnZGQ" protobufEnumeration="1" base_EnumerationLiteral="__6_sAkcnEe6bIJjw8ZnZGQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_aRxR0EcwEe6bIJjw8ZnZGQ" protobufEnumeration="2" base_EnumerationLiteral="__6_sBEcnEe6bIJjw8ZnZGQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_d_gH0EcwEe6bIJjw8ZnZGQ" protobufEnumeration="3" base_EnumerationLiteral="__6_sBUcnEe6bIJjw8ZnZGQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_kkYxIEcwEe6bIJjw8ZnZGQ" protobufEnumeration="4" base_EnumerationLiteral="__6_sB0cnEe6bIJjw8ZnZGQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_oPaRYEcwEe6bIJjw8ZnZGQ" protobufEnumeration="5" base_EnumerationLiteral="__6_sCUcnEe6bIJjw8ZnZGQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_uNdkMEcwEe6bIJjw8ZnZGQ" protobufEnumeration="6" base_EnumerationLiteral="__6_sC0cnEe6bIJjw8ZnZGQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_x5LoAEcwEe6bIJjw8ZnZGQ" protobufEnumeration="7" base_EnumerationLiteral="__6_sDUcnEe6bIJjw8ZnZGQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_2bDQsEcwEe6bIJjw8ZnZGQ" protobufEnumeration="8" base_EnumerationLiteral="__6_sD0cnEe6bIJjw8ZnZGQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_I1CfwEcxEe6bIJjw8ZnZGQ" protobufEnumeration="9" base_EnumerationLiteral="__6_sEUcnEe6bIJjw8ZnZGQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_MNm-EEcxEe6bIJjw8ZnZGQ" protobufEnumeration="10" base_EnumerationLiteral="__6_sE0cnEe6bIJjw8ZnZGQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_PoNcsEcxEe6bIJjw8ZnZGQ" protobufEnumeration="11" base_EnumerationLiteral="__6_sFUcnEe6bIJjw8ZnZGQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_UhBlwEcxEe6bIJjw8ZnZGQ" protobufEnumeration="12" base_EnumerationLiteral="__6_sF0cnEe6bIJjw8ZnZGQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_YEtu8EcxEe6bIJjw8ZnZGQ" protobufEnumeration="13" base_EnumerationLiteral="__6_sGUcnEe6bIJjw8ZnZGQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_bcFTYEcxEe6bIJjw8ZnZGQ" protobufEnumeration="14" base_EnumerationLiteral="__6_sG0cnEe6bIJjw8ZnZGQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_fYEn0EcxEe6bIJjw8ZnZGQ" protobufEnumeration="15" base_EnumerationLiteral="__6_sHUcnEe6bIJjw8ZnZGQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_jALW8EcxEe6bIJjw8ZnZGQ" protobufEnumeration="16" base_EnumerationLiteral="__6_sH0cnEe6bIJjw8ZnZGQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_mlDL4EcxEe6bIJjw8ZnZGQ" protobufEnumeration="17" base_EnumerationLiteral="__6_sIUcnEe6bIJjw8ZnZGQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_qCEFUEcxEe6bIJjw8ZnZGQ" protobufEnumeration="18" base_EnumerationLiteral="__6_sI0cnEe6bIJjw8ZnZGQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_1-CvIEcxEe6bIJjw8ZnZGQ" protobufEnumeration="19" base_EnumerationLiteral="__6_sJEcnEe6bIJjw8ZnZGQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_6GqxYEcxEe6bIJjw8ZnZGQ" protobufEnumeration="20" base_EnumerationLiteral="__6_sJUcnEe6bIJjw8ZnZGQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_9cbzUEcxEe6bIJjw8ZnZGQ" protobufEnumeration="21" base_EnumerationLiteral="__6_sJkcnEe6bIJjw8ZnZGQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_AxZkAEcyEe6bIJjw8ZnZGQ" protobufEnumeration="22" base_EnumerationLiteral="__6_sJ0cnEe6bIJjw8ZnZGQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_ESpdMEcyEe6bIJjw8ZnZGQ" protobufEnumeration="23" base_EnumerationLiteral="__6_sKUcnEe6bIJjw8ZnZGQ"/>
-  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_HsGsUEcyEe6bIJjw8ZnZGQ" protobufEnumeration="24" base_EnumerationLiteral="__6_sKkcnEe6bIJjw8ZnZGQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_QLqZ8EcvEe6bIJjw8ZnZGQ" protobufEnumeration="1" base_EnumerationLiteral="__6_sAUcnEe6bIJjw8ZnZGQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_UBhRMEcvEe6bIJjw8ZnZGQ" protobufEnumeration="2" base_EnumerationLiteral="__6_sAkcnEe6bIJjw8ZnZGQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_aRxR0EcwEe6bIJjw8ZnZGQ" protobufEnumeration="3" base_EnumerationLiteral="__6_sBEcnEe6bIJjw8ZnZGQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_d_gH0EcwEe6bIJjw8ZnZGQ" protobufEnumeration="4" base_EnumerationLiteral="__6_sBUcnEe6bIJjw8ZnZGQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_kkYxIEcwEe6bIJjw8ZnZGQ" protobufEnumeration="5" base_EnumerationLiteral="__6_sB0cnEe6bIJjw8ZnZGQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_oPaRYEcwEe6bIJjw8ZnZGQ" protobufEnumeration="6" base_EnumerationLiteral="__6_sCUcnEe6bIJjw8ZnZGQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_uNdkMEcwEe6bIJjw8ZnZGQ" protobufEnumeration="7" base_EnumerationLiteral="__6_sC0cnEe6bIJjw8ZnZGQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_x5LoAEcwEe6bIJjw8ZnZGQ" protobufEnumeration="8" base_EnumerationLiteral="__6_sDUcnEe6bIJjw8ZnZGQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_2bDQsEcwEe6bIJjw8ZnZGQ" protobufEnumeration="9" base_EnumerationLiteral="__6_sD0cnEe6bIJjw8ZnZGQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_I1CfwEcxEe6bIJjw8ZnZGQ" protobufEnumeration="10" base_EnumerationLiteral="__6_sEUcnEe6bIJjw8ZnZGQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_MNm-EEcxEe6bIJjw8ZnZGQ" protobufEnumeration="11" base_EnumerationLiteral="__6_sE0cnEe6bIJjw8ZnZGQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_PoNcsEcxEe6bIJjw8ZnZGQ" protobufEnumeration="12" base_EnumerationLiteral="__6_sFUcnEe6bIJjw8ZnZGQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_UhBlwEcxEe6bIJjw8ZnZGQ" protobufEnumeration="13" base_EnumerationLiteral="__6_sF0cnEe6bIJjw8ZnZGQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_YEtu8EcxEe6bIJjw8ZnZGQ" protobufEnumeration="14" base_EnumerationLiteral="__6_sGUcnEe6bIJjw8ZnZGQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_bcFTYEcxEe6bIJjw8ZnZGQ" protobufEnumeration="15" base_EnumerationLiteral="__6_sG0cnEe6bIJjw8ZnZGQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_fYEn0EcxEe6bIJjw8ZnZGQ" protobufEnumeration="16" base_EnumerationLiteral="__6_sHUcnEe6bIJjw8ZnZGQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_jALW8EcxEe6bIJjw8ZnZGQ" protobufEnumeration="17" base_EnumerationLiteral="__6_sH0cnEe6bIJjw8ZnZGQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_mlDL4EcxEe6bIJjw8ZnZGQ" protobufEnumeration="18" base_EnumerationLiteral="__6_sIUcnEe6bIJjw8ZnZGQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_qCEFUEcxEe6bIJjw8ZnZGQ" protobufEnumeration="19" base_EnumerationLiteral="__6_sI0cnEe6bIJjw8ZnZGQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_1-CvIEcxEe6bIJjw8ZnZGQ" protobufEnumeration="20" base_EnumerationLiteral="__6_sJEcnEe6bIJjw8ZnZGQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_6GqxYEcxEe6bIJjw8ZnZGQ" protobufEnumeration="21" base_EnumerationLiteral="__6_sJUcnEe6bIJjw8ZnZGQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_9cbzUEcxEe6bIJjw8ZnZGQ" protobufEnumeration="24" base_EnumerationLiteral="__6_sJkcnEe6bIJjw8ZnZGQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_AxZkAEcyEe6bIJjw8ZnZGQ" protobufEnumeration="25" base_EnumerationLiteral="__6_sJ0cnEe6bIJjw8ZnZGQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_ESpdMEcyEe6bIJjw8ZnZGQ" protobufEnumeration="26" base_EnumerationLiteral="__6_sKUcnEe6bIJjw8ZnZGQ"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_HsGsUEcyEe6bIJjw8ZnZGQ" protobufEnumeration="27" base_EnumerationLiteral="__6_sKkcnEe6bIJjw8ZnZGQ"/>
   <OpenModel_Profile:OpenModelClass xmi:id="_KRgyMVIQEe6m_d6KGfEFwg" base_Class="_KRgyMFIQEe6m_d6KGfEFwg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelClass xmi:id="_KRrKQFIQEe6m_d6KGfEFwg" base_Class="_KRgyMFIQEe6m_d6KGfEFwg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_S1iBtFIQEe6m_d6KGfEFwg" base_Property="_S1iBs1IQEe6m_d6KGfEFwg"/>
@@ -1212,4 +1242,11 @@ Hence the YANG should convert into a protobuf map.</body>
   <OpenModel_Profile:ExtendedComposite xmi:id="_dkaUUFISEe6m_d6KGfEFwg" base_Association="_VET7gFISEe6m_d6KGfEFwg"/>
   <OpenInterfaceModel_Profile:OpenInterfaceModelAttribute xmi:id="_VluFkVebEe6mE7NoRC7Zaw" base_Property="_VluFkFebEe6mE7NoRC7Zaw" protobufEnumeration="17"/>
   <OpenModel_Profile:OpenModelAttribute xmi:id="_VlzlIFebEe6mE7NoRC7Zaw" base_StructuralFeature="_VluFkFebEe6mE7NoRC7Zaw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_qLeKwHcaEe6iN6ao8wePZw" protobufEnumeration="0" base_EnumerationLiteral="_lH_CwHcaEe6iN6ao8wePZw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_TLGUgHccEe6iN6ao8wePZw" protobufEnumeration="0" base_EnumerationLiteral="_Gux9wHccEe6iN6ao8wePZw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_x3VQ8HcfEe6iN6ao8wePZw" protobufEnumeration="0" base_EnumerationLiteral="_RpcNIHcfEe6iN6ao8wePZw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_n3_LkHciEe6iN6ao8wePZw" protobufEnumeration="28" base_EnumerationLiteral="_knymIHciEe6iN6ao8wePZw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_vXoM8HciEe6iN6ao8wePZw" protobufEnumeration="29" base_EnumerationLiteral="_sSqnIHciEe6iN6ao8wePZw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_xkH7oHfQEe6iN6ao8wePZw" protobufEnumeration="22" base_EnumerationLiteral="_aTg74HfQEe6iN6ao8wePZw"/>
+  <OpenInterfaceModel_Profile:OpenInterfaceEnumerationLiteral xmi:id="_2ANFYHfQEe6iN6ao8wePZw" protobufEnumeration="23" base_EnumerationLiteral="_dmUwcHfQEe6iN6ao8wePZw"/>
 </xmi:XMI>


### PR DESCRIPTION
ValueQualifier
a. comment positioned correctly in ValueQualifier not in SampleQualifier (minor)
b. updated to have default (0) literal of OK
c. literals all shifted by 1 to accommodate “OK”
d. usage in QualifiedMeasuredValue set default to OK

SampleQualifier
a. updated to have default (0) literal of NORMAL
b. literals all shifted by 1 to accommodate “NORMAL” 
c. usage in QualifiedMeasurementCommon1To10 set default to NORMAL

DirectionOfMeasuredSignal
a. comment on NO_DIRECTION in DirectionOfMeasuredSignal improved to allow it to be used as a default (0) where the direction is obvious from the measurement type
b. usage in QualifiedMeasurementCommon1To10 set default to NO_DIRECTION

NormalizedMeasurementType
a. updated to have default (0) literal of NO_NORMALIZED_TYPE 
b. literals all shifted by 1 to accommodate “NO_NORMALIZED_TYPE” 
c. usage in QualifiedMeasurementCommon1To10 set default to NO_NORMALIZED_TYPE
d. was not aligned with pm
       i.    DELAY updated to DELAY_FRAME_COUNT
       ii.   OPTICAL_POWER_INPUT changed to OPT_TOTAL_PWR_INPUT
       iii.  OPTICAL_POWER_OUTPUT changed to OPT_TOTAL_PWR_OUTPUT
       iv.   OPT_PWR_SPECTR_DENS_INPUT added
       v.    OPT_PWR_SPECTR_DENS_OUTPUT added
       vi.   VOA_INPUT added
       vii.  VOA_OUTPUT added

Further enhancements
a. associations in TypeDefinitions moved to associations 
b. comments on default literals improved
c. diagrams updated